### PR TITLE
Remove RunnableCommand interface in favour of abstract.

### DIFF
--- a/src/abstracts/Command.ts
+++ b/src/abstracts/Command.ts
@@ -1,3 +1,5 @@
+import { Message } from "discord.js";
+
 abstract class Command {
 	private readonly name: string;
 	private readonly description: string;
@@ -6,6 +8,8 @@ abstract class Command {
 		this.name = name;
 		this.description = description;
 	}
+
+	abstract async run(message: Message, args?: string[]): Promise<void>;
 
 	getName(): string {
 		return this.name;

--- a/src/commands/HiringLookingCommand.ts
+++ b/src/commands/HiringLookingCommand.ts
@@ -1,8 +1,7 @@
 import { Message, MessageEmbed } from "discord.js";
 import Command from "../abstracts/Command";
-import RunnableCommand from "../interfaces/RunnableCommand";
 
-class HiringLookingCommand extends Command implements RunnableCommand {
+class HiringLookingCommand extends Command {
 	constructor() {
 		super(
 			"hl",

--- a/src/commands/RuleCommand.ts
+++ b/src/commands/RuleCommand.ts
@@ -1,9 +1,8 @@
 import { Message, MessageEmbed } from "discord.js";
 import { rules } from "../config.json";
 import Command from "../abstracts/Command";
-import RunnableCommand from "../interfaces/RunnableCommand";
 
-class RuleCommand extends Command implements RunnableCommand {
+class RuleCommand extends Command {
 	constructor() {
 		super(
 			"rule",

--- a/src/factories/CommandFactory.ts
+++ b/src/factories/CommandFactory.ts
@@ -1,6 +1,6 @@
 import { commands_directory } from "../config.json";
 import { readDirectory } from "../utils/readDirectory";
-import RunnableCommand from "../interfaces/RunnableCommand";
+import Command from "../abstracts/Command";
 
 class CommandFactory {
 	private commands: any = {};
@@ -23,7 +23,7 @@ class CommandFactory {
 		return typeof this.commands[command] !== "undefined";
 	}
 
-	getCommand(command: string): RunnableCommand {
+	getCommand(command: string): Command {
 		return this.commands[command]();
 	}
 }

--- a/src/interfaces/RunnableCommand.ts
+++ b/src/interfaces/RunnableCommand.ts
@@ -1,7 +1,0 @@
-import { Message } from "discord.js";
-
-interface RunnableCommand {
-	run(message: Message, args?: string[]): Promise<void>;
-}
-
-export default RunnableCommand;

--- a/test/commands/HiringLookingCommandTest.ts
+++ b/test/commands/HiringLookingCommandTest.ts
@@ -4,8 +4,8 @@ import { Message } from "discord.js";
 
 // @ts-ignore - TS does not like MockDiscord not living in src/
 import MockDiscord from "../MockDiscord";
-import RunnableCommand from "../../src/interfaces/RunnableCommand";
 import HiringLookingCommand from "../../src/commands/HiringLookingCommand";
+import Command from "../../src/abstracts/Command";
 
 describe("RuleCommand", () => {
 	describe("constructor()", () => {
@@ -25,7 +25,7 @@ describe("RuleCommand", () => {
 	describe("run()", () => {
 		let sandbox: SinonSandbox;
 		let message: Message;
-		let command: RunnableCommand;
+		let command: Command;
 		let discordMock: MockDiscord;
 
 		beforeEach(() => {

--- a/test/commands/RuleCommandTest.ts
+++ b/test/commands/RuleCommandTest.ts
@@ -5,7 +5,7 @@ import { Message } from "discord.js";
 // @ts-ignore - TS does not like MockDiscord not living in src/
 import MockDiscord from "../MockDiscord";
 import RuleCommand from "../../src/commands/RuleCommand";
-import RunnableCommand from "../../src/interfaces/RunnableCommand";
+import Command from "../../src/abstracts/Command";
 
 describe("RuleCommand", () => {
 	describe("constructor()", () => {
@@ -25,7 +25,7 @@ describe("RuleCommand", () => {
 	describe("run()", () => {
 		let sandbox: SinonSandbox;
 		let message: Message;
-		let command: RunnableCommand;
+		let command: Command;
 		let discordMock: MockDiscord;
 
 		beforeEach(() => {


### PR DESCRIPTION
#### Overview
- Removed `RunnableCommand` interface in favour of defining `run()` in the `abstract Command`