### PR TITLE
User Authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./build/app.js",
     "build": "tsc",
-    "test": "ts-mocha test/**/*Test.ts --exit"
+    "test": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts --exit"
   },
   "repository": {
     "type": "git",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
-import { Client } from "discord.js";
+import {Client, TextChannel} from "discord.js";
 import getFilesInDirectory from "./utils/getFilesInDirectory";
-import { handlers_directory } from "./config.json";
+import { handlers_directory, AUTHENTICATION_MESSAGE_CHANNEL, AUTHENTICATION_MESSAGE_ID } from "./config.json";
 
 const client = new Client();
 
@@ -8,7 +8,6 @@ const client = new Client();
 	if (process.env.DISCORD_TOKEN) {
 		try {
 			await client.login(process.env.DISCORD_TOKEN);
-
 			console.log(`Successfully logged in as ${client.user?.username}`);
 
 			const handlerFiles = await getFilesInDirectory(
@@ -22,6 +21,10 @@ const client = new Client();
 
 				client.on(handlerInstance.getEvent(), handlerInstance.handle);
 			});
+
+			const authChannel = await client.channels.fetch(AUTHENTICATION_MESSAGE_CHANNEL) as TextChannel;
+
+			await authChannel.messages.fetch(AUTHENTICATION_MESSAGE_ID);
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/config.json
+++ b/src/config.json
@@ -1,5 +1,8 @@
 {
     "COMMAND_PREFIX": "?",
+    "MEMBER_ROLE": "592088198746996768",
+    "AUTHENTICATION_MESSAGE_ID": "592316062796873738",
+    "AUTHENTICATION_MESSAGE_CHANNEL": "592087564295471105",
     "commands_directory": "commands",
     "handlers_directory": "event/handlers",
     "rules": [

--- a/src/event/handlers/AutomaticMemberRoleHandler.ts
+++ b/src/event/handlers/AutomaticMemberRoleHandler.ts
@@ -1,0 +1,23 @@
+import { Constants, GuildMember } from "discord.js";
+import { MEMBER_ROLE } from "../../config.json";
+import EventHandler from "../../abstracts/EventHandler";
+
+class AutomaticMemberRoleHandler extends EventHandler {
+	constructor() {
+		super(Constants.Events.GUILD_MEMBER_ADD);
+	}
+
+	async handle(member: GuildMember): Promise<void> {
+		const currentDate = Date.now();
+		const memberCreatedDate = member.user.createdAt.getTime();
+		const dateDifference = currentDate - memberCreatedDate;
+		const hasAvatar = member.user.avatar;
+		const is30DaysOld = dateDifference / 2592000000 > 1;
+
+		if (hasAvatar && is30DaysOld) {
+			await member.roles.add(MEMBER_ROLE, "Appears to be a valid account.");
+		}
+	}
+}
+
+export default AutomaticMemberRoleHandler;

--- a/src/event/handlers/NewUserAuthenticationHandler.ts
+++ b/src/event/handlers/NewUserAuthenticationHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, MessageReaction, User} from "discord.js";
+import { Constants, MessageReaction, User } from "discord.js";
 import { AUTHENTICATION_MESSAGE_ID, MEMBER_ROLE } from "../../config.json";
 import EventHandler from "../../abstracts/EventHandler";
 
@@ -11,7 +11,6 @@ class NewUserAuthenticationHandler extends EventHandler {
 		const { message, emoji } = reaction;
 		const isAuthMessage = message.id === AUTHENTICATION_MESSAGE_ID;
 		const isAuthEmoji = emoji.name === "🤖";
-
 
 		if (isAuthMessage && isAuthEmoji) {
 			const guildMember = await reaction.message.guild?.members.fetch(member);

--- a/src/event/handlers/NewUserAuthenticationHandler.ts
+++ b/src/event/handlers/NewUserAuthenticationHandler.ts
@@ -1,0 +1,24 @@
+import {Constants, MessageReaction, User} from "discord.js";
+import { AUTHENTICATION_MESSAGE_ID, MEMBER_ROLE } from "../../config.json";
+import EventHandler from "../../abstracts/EventHandler";
+
+class NewUserAuthenticationHandler extends EventHandler {
+	constructor() {
+		super(Constants.Events.MESSAGE_REACTION_ADD);
+	}
+
+	async handle(reaction: MessageReaction, member: User): Promise<void> {
+		const { message, emoji } = reaction;
+		const isAuthMessage = message.id === AUTHENTICATION_MESSAGE_ID;
+		const isAuthEmoji = emoji.name === "🤖";
+
+
+		if (isAuthMessage && isAuthEmoji) {
+			const guildMember = await reaction.message.guild?.members.fetch(member);
+
+			await guildMember?.roles.add(MEMBER_ROLE, "User has authenticated their account.");
+		}
+	}
+}
+
+export default NewUserAuthenticationHandler;

--- a/test/MockDiscord.ts
+++ b/test/MockDiscord.ts
@@ -1,4 +1,4 @@
-import Discord from "discord.js";
+import Discord, {Client, GuildEmoji, Message, ReactionEmoji, ReactionUserManager} from "discord.js";
 
 // Shoutout to TotomInc on GitHub for making this, you're a life saver. <3
 // It has been slightly modified to work with the latest version of Discord.js.
@@ -13,6 +13,7 @@ export default class MockDiscord {
 	private user!: Discord.User;
 	private guildMember!: Discord.GuildMember;
 	private message!: Discord.Message;
+	private messageReaction!: Discord.MessageReaction;
 
 	constructor() {
 		this.mockClient();
@@ -30,6 +31,8 @@ export default class MockDiscord {
 		this.mockGuildMember();
 
 		this.mockMessage();
+
+		this.mockMessageReaction();
 	}
 
 	public getClient(): Discord.Client {
@@ -62,6 +65,10 @@ export default class MockDiscord {
 
 	public getMessage(): Discord.Message {
 		return this.message;
+	}
+
+	public getMessageReaction(): Discord.MessageReaction {
+		return this.messageReaction;
 	}
 
 	private mockClient(): void {
@@ -174,6 +181,19 @@ export default class MockDiscord {
 				hit: false,
 			},
 			this.textChannel,
+		);
+	}
+
+	private mockMessageReaction(): void {
+		this.messageReaction = new Discord.MessageReaction(
+			this.client,
+			{
+				message: this.message,
+				emoji: {
+					name: 'emoji-name'
+				}
+			},
+			this.message
 		);
 	}
 }

--- a/test/commands/HiringLookingCommandTest.ts
+++ b/test/commands/HiringLookingCommandTest.ts
@@ -7,7 +7,7 @@ import MockDiscord from "../MockDiscord";
 import HiringLookingCommand from "../../src/commands/HiringLookingCommand";
 import Command from "../../src/abstracts/Command";
 
-describe("RuleCommand", () => {
+describe("HiringLookingCommand", () => {
 	describe("constructor()", () => {
 		it("creates a command called hl", () => {
 			const command = new HiringLookingCommand();

--- a/test/event/handlers/AutomaticMemberRoleHandlerTest.ts
+++ b/test/event/handlers/AutomaticMemberRoleHandlerTest.ts
@@ -1,0 +1,45 @@
+import { expect } from "chai";
+import {Constants, GuildMember} from "discord.js";
+import AutomaticMemberRoleHandler from "../../../src/event/handlers/AutomaticMemberRoleHandler";
+import { SinonSandbox, createSandbox } from "sinon";
+import EventHandler from "../../../src/abstracts/EventHandler";
+// @ts-ignore - TS does not like MockDiscord not living in src/
+import MockDiscord from "../../MockDiscord";
+
+describe("AutomaticMemberRoleHandler", () => {
+	describe("constructor()", () => {
+		it("creates a handler for GUILD_MEMBER_ADD", () => {
+			const handler = new AutomaticMemberRoleHandler();
+
+			expect(handler.getEvent()).to.equal(Constants.Events.GUILD_MEMBER_ADD);
+		});
+	});
+
+	describe("handle()", () => {
+		let sandbox: SinonSandbox;
+		let handler: EventHandler;
+		let discordMock: MockDiscord;
+		let member: GuildMember;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+			handler = new AutomaticMemberRoleHandler();
+			discordMock = new MockDiscord();
+			member = discordMock.getGuildMember();
+		});
+
+		it("doesn't give the member the role if they don't have an avatar", async () => {
+			member.user.avatar = null;
+
+			const addMock = sandbox.stub(member.roles, "add");
+
+			await handler.handle(member);
+
+			expect(addMock.calledOnce).to.be.false;
+		});
+
+		afterEach(() => {
+			sandbox.reset();
+		});
+	});
+});

--- a/test/event/handlers/NewUserAuthenticationHandlerTest.ts
+++ b/test/event/handlers/NewUserAuthenticationHandlerTest.ts
@@ -1,0 +1,101 @@
+import { expect } from "chai";
+import { createSandbox, SinonSandbox } from "sinon";
+import { Constants, MessageReaction, User } from "discord.js";
+import NewUserAuthenticationHandler from "../../../src/event/handlers/NewUserAuthenticationHandler";
+import EventHandler from "../../../src/abstracts/EventHandler";
+// @ts-ignore
+import MockDiscord from "../../MockDiscord";
+
+describe("NewUserAuthenticationHandler", () => {
+	describe("constructor()", () => {
+		it("creates a handler for MESSAGE_REACTION_ADD", () => {
+			const handler = new NewUserAuthenticationHandler();
+
+			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_REACTION_ADD);
+		});
+	});
+
+	describe("handle()", () => {
+		let sandbox: SinonSandbox;
+		let handler: EventHandler;
+		let discordMock: MockDiscord;
+		let reaction: MessageReaction;
+		let user: User;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+			handler = new NewUserAuthenticationHandler();
+			discordMock = new MockDiscord();
+			reaction = discordMock.getMessageReaction();
+			user = discordMock.getUser();
+		});
+
+		it("gives the user the member role if they meet the requirements", async () => {
+			reaction.message.id = "592316062796873738";
+			reaction.emoji.name = "🤖";
+
+			// @ts-ignore
+			const fetchMock = sandbox.stub(reaction.message.guild?.members, "fetch").resolves({
+				roles: {
+					add: async (role: string, reason: string) => [role, reason]
+				}
+			});
+
+			await handler.handle(reaction, user);
+
+			expect(fetchMock.calledOnce).to.be.true;
+		});
+
+		it("does not give the user the member role if they react with the wrong emoji", async () => {
+			reaction.message.id = "592316062796873738";
+			reaction.emoji.name = "😀";
+
+			// @ts-ignore
+			const fetchMock = sandbox.stub(reaction.message.guild?.members, "fetch").resolves({
+				roles: {
+					add: async (role: string, reason: string) => [role, reason]
+				}
+			});
+
+			await handler.handle(reaction, user);
+
+			expect(fetchMock.calledOnce).to.be.false;
+		});
+
+		it("does not give the user the member role if they react to the wrong message", async () => {
+			reaction.message.id = "1234";
+			reaction.emoji.name = "🤖";
+
+			// @ts-ignore
+			const fetchMock = sandbox.stub(reaction.message.guild?.members, "fetch").resolves({
+				roles: {
+					add: async (role: string, reason: string) => [role, reason]
+				}
+			});
+
+			await handler.handle(reaction, user);
+
+			expect(fetchMock.calledOnce).to.be.false;
+		});
+
+		it("does not give the user the member role if they react to the wrong message with the wrong emoji", async () => {
+			reaction.message.id = "1234";
+			reaction.emoji.name = "😀";
+
+			// @ts-ignore
+			const fetchMock = sandbox.stub(reaction.message.guild?.members, "fetch").resolves({
+				roles: {
+					add: async (role: string, reason: string) => [role, reason]
+				}
+			});
+
+			await handler.handle(reaction, user);
+
+			expect(fetchMock.calledOnce).to.be.false;
+		});
+
+		afterEach(() => {
+			sandbox.reset();
+		});
+	});
+});


### PR DESCRIPTION
- Allow users to authenticate their account when they react with a robot
- Automatically give new members the Member role if they match the criteria
- Added `MEMBER_ROLE` constant to `config.json`
- Added `AUTHENTICATION_MESSAGE_ID` constant to `config.json` 
- Added `AUTHENTICATION_MESSAGE_CHANNEL` constant to `config.json` 
- Cached the authentication message