### PR TITLE
Added alias functionality

### DIFF
--- a/src/abstracts/Command.ts
+++ b/src/abstracts/Command.ts
@@ -5,13 +5,11 @@ abstract class Command {
 	private readonly name: string;
 	private readonly description: string;
 	private readonly options: CommandOptions | undefined;
-	private readonly aliases: Array<string>;
 
-	protected constructor(name: string, description: string, options?: CommandOptions, aliases: Array<string> = []) {
+	protected constructor(name: string, description: string, options?: CommandOptions) {
 		this.name = name;
 		this.description = description;
 		this.options = options;
-		this.aliases = aliases;
 	}
 
 	abstract async run(message: Message, args?: string[]): Promise<void>;
@@ -24,8 +22,8 @@ abstract class Command {
 		return this.description;
 	}
 
-	getAliases(): Array<string> {
-		return this.aliases;
+	getAliases(): string[] {
+		return this.options?.aliases || [];
 	}
 
 	isSelfDestructing(): boolean {

--- a/src/abstracts/Command.ts
+++ b/src/abstracts/Command.ts
@@ -5,11 +5,13 @@ abstract class Command {
 	private readonly name: string;
 	private readonly description: string;
 	private readonly options: CommandOptions | undefined;
+	private readonly aliases: Array<string>;
 
-	protected constructor(name: string, description: string, options?: CommandOptions) {
+	protected constructor(name: string, description: string, options?: CommandOptions, aliases: Array<string> = []) {
 		this.name = name;
 		this.description = description;
 		this.options = options;
+		this.aliases = aliases;
 	}
 
 	abstract async run(message: Message, args?: string[]): Promise<void>;
@@ -20,6 +22,10 @@ abstract class Command {
 
 	getDescription(): string {
 		return this.description;
+	}
+
+	getAliases(): Array<string> {
+		return this.aliases;
 	}
 
 	isSelfDestructing(): boolean {

--- a/src/commands/CodeblockCommand.ts
+++ b/src/commands/CodeblockCommand.ts
@@ -7,9 +7,9 @@ class CodeblockCommand extends Command {
 			"codeblock",
 			"Shows a tutorial on how to use Discord's codeblocks.",
 			{
-				selfDestructing: true
+				selfDestructing: true,
+				aliases: ["codeblocks", "cb"]
 			},
-			["codeblocks", "cb"]
 		);
 	}
 

--- a/src/commands/CodeblockCommand.ts
+++ b/src/commands/CodeblockCommand.ts
@@ -8,7 +8,8 @@ class CodeblockCommand extends Command {
 			"Shows a tutorial on how to use Discord's codeblocks.",
 			{
 				selfDestructing: true
-			}
+			},
+			["codeblocks", "cb"]
 		);
 	}
 

--- a/src/factories/CommandFactory.ts
+++ b/src/factories/CommandFactory.ts
@@ -16,6 +16,12 @@ class CommandFactory {
 			const name = new Command().getName().toLowerCase();
 
 			this.commands[name] = () => new Command();
+
+			const aliases = new Command().getAliases();
+
+			aliases.forEach((alias: string) => {
+				this.commands[alias] = () => new Command();
+			});
 		});
 	}
 

--- a/src/interfaces/CommandOptions.ts
+++ b/src/interfaces/CommandOptions.ts
@@ -1,5 +1,6 @@
 interface CommandOptions {
 	selfDestructing?: boolean;
+	aliases?: string[];
 }
 
 export default CommandOptions;

--- a/test/MockCommandWithAlias.ts
+++ b/test/MockCommandWithAlias.ts
@@ -5,10 +5,11 @@ export default class MockCommandWithAlias extends Command {
 	constructor() {
 		super(
 			"mock-alias",
-			"Mock Command With Alias",
+			"Mock Command with Aliases",
 			{
-				aliases: ["mocky", "mockster"]
-			});
+				aliases: ["mocky", "mocko"]
+			}
+		);
 	}
 
 	async run(message: Message, args: string[]): Promise<void> {

--- a/test/MockCommandWithAlias.ts
+++ b/test/MockCommandWithAlias.ts
@@ -1,9 +1,14 @@
 import Command from "../src/abstracts/Command";
 import { Message } from "discord.js";
 
-export default class MockCommand extends Command {
+export default class MockCommandWithAlias extends Command {
 	constructor() {
-		super("mock", "Mock Command");
+		super(
+			"mock-alias",
+			"Mock Command With Alias",
+			{
+				aliases: ["mocky", "mockster"]
+			});
 	}
 
 	async run(message: Message, args: string[]): Promise<void> {

--- a/test/commands/CodeblockCommandTest.ts
+++ b/test/commands/CodeblockCommandTest.ts
@@ -20,6 +20,13 @@ describe("CodeblockCommand", () => {
 
 			expect(command.getDescription()).to.equal("Shows a tutorial on how to use Discord's codeblocks.");
 		});
+
+		it("creates a command with correct aliases", () => {
+			const command = new CodeblockCommand();
+
+			expect(command.getAliases().includes("codeblocks")).to.equal(true);
+			expect(command.getAliases().includes("cb")).to.equal(true);
+		});
 	});
 
 	describe("run()", () => {

--- a/test/commands/CodeblockCommandTest.ts
+++ b/test/commands/CodeblockCommandTest.ts
@@ -20,13 +20,6 @@ describe("CodeblockCommand", () => {
 
 			expect(command.getDescription()).to.equal("Shows a tutorial on how to use Discord's codeblocks.");
 		});
-
-		it("creates a command with correct aliases", () => {
-			const command = new CodeblockCommand();
-
-			expect(command.getAliases().includes("codeblocks")).to.equal(true);
-			expect(command.getAliases().includes("cb")).to.equal(true);
-		});
 	});
 
 	describe("run()", () => {

--- a/test/factories/CommandFactoryTest.ts
+++ b/test/factories/CommandFactoryTest.ts
@@ -3,17 +3,28 @@ import { expect } from "chai";
 import CommandFactory from "../../src/factories/CommandFactory";
 // @ts-ignore - TS does not like MockCommand not living in src/
 import MockCommand from "../MockCommand";
+import MockCommandWithAlias from "../MockCommandWithAlias";
 
 describe("CommandFactory", () => {
     let factory: CommandFactory;
     let commandName: string;
+	let commandWithAliasesName: string;
+	let aliases: string[];
 
     before(() => {
-        factory = new CommandFactory();
         commandName = new MockCommand().getName();
+		commandWithAliasesName = new MockCommandWithAlias().getName();
+		aliases = new MockCommandWithAlias().getAliases();
+
+		factory = new CommandFactory();
         factory["commands"] = {};
         factory["commands"][commandName] = () => new MockCommand();
-    });
+		factory["commands"][commandWithAliasesName] = () => new MockCommandWithAlias();
+
+		aliases.forEach(alias => {
+			factory["commands"][alias] = () => new MockCommandWithAlias();
+		});
+	});
 
     describe("commandExists()", () => {
         it("checks to see a command exists", () => {
@@ -30,7 +41,13 @@ describe("CommandFactory", () => {
 
         it("checks to see a command doesn't exist", () => {
             expect(factory.commandExists("bad command")).to.be.false;
-        });
+		});
+		
+		it("checks to see a command exists by it's aliases", () => {
+			aliases.forEach(alias => {
+				expect(factory.commandExists(alias)).to.be.true;
+			});
+		});
     });
 
     describe("getCommand()", () => {
@@ -44,6 +61,12 @@ describe("CommandFactory", () => {
 
         it("gets a mocked command - uppercase", () => {
             expect(factory.getCommand(commandName.toUpperCase())).to.be.a("object");
-        });
+		});
+		
+		it("gets a mocked command by it's aliases", () => {
+			aliases.forEach(alias => {
+				expect(factory.getCommand(alias)).to.be.a("object");
+			});
+		});
     });
 });

--- a/test/factories/CommandFactoryTest.ts
+++ b/test/factories/CommandFactoryTest.ts
@@ -6,19 +6,19 @@ import MockCommand from "../MockCommand";
 import MockCommandWithAlias from "../MockCommandWithAlias";
 
 describe("CommandFactory", () => {
-    let factory: CommandFactory;
-    let commandName: string;
+	let factory: CommandFactory;
+	let commandName: string;
 	let commandWithAliasesName: string;
 	let aliases: string[];
 
-    before(() => {
-        commandName = new MockCommand().getName();
+	before(() => {
+		commandName = new MockCommand().getName();
 		commandWithAliasesName = new MockCommandWithAlias().getName();
 		aliases = new MockCommandWithAlias().getAliases();
 
 		factory = new CommandFactory();
-        factory["commands"] = {};
-        factory["commands"][commandName] = () => new MockCommand();
+		factory["commands"] = {};
+		factory["commands"][commandName] = () => new MockCommand();
 		factory["commands"][commandWithAliasesName] = () => new MockCommandWithAlias();
 
 		aliases.forEach(alias => {
@@ -26,47 +26,47 @@ describe("CommandFactory", () => {
 		});
 	});
 
-    describe("commandExists()", () => {
-        it("checks to see a command exists", () => {
-            expect(factory.commandExists(commandName)).to.be.true;
-        });
-
-        it("checks to see a command exists - lowercase", () => {
-            expect(factory.commandExists(commandName.toLowerCase())).to.be.true;
-        });
-
-        it("checks to see a command exists - uppercase", () => {
-            expect(factory.commandExists(commandName.toUpperCase())).to.be.true;
-        });
-
-        it("checks to see a command doesn't exist", () => {
-            expect(factory.commandExists("bad command")).to.be.false;
+	describe("commandExists()", () => {
+		it("checks to see a command exists", () => {
+			expect(factory.commandExists(commandName)).to.be.true;
 		});
-		
+
+		it("checks to see a command exists - lowercase", () => {
+			expect(factory.commandExists(commandName.toLowerCase())).to.be.true;
+		});
+
+		it("checks to see a command exists - uppercase", () => {
+			expect(factory.commandExists(commandName.toUpperCase())).to.be.true;
+		});
+
+		it("checks to see a command doesn't exist", () => {
+			expect(factory.commandExists("bad command")).to.be.false;
+		});
+
 		it("checks to see a command exists by it's aliases", () => {
 			aliases.forEach(alias => {
 				expect(factory.commandExists(alias)).to.be.true;
 			});
 		});
-    });
+	});
 
-    describe("getCommand()", () => {
-        it("gets a mocked command", () => {
-            expect(factory.getCommand(commandName)).to.be.a("object");
-        });
-
-        it("gets a mocked command - lowercase", () => {
-            expect(factory.getCommand(commandName.toLowerCase())).to.be.a("object");
-        });
-
-        it("gets a mocked command - uppercase", () => {
-            expect(factory.getCommand(commandName.toUpperCase())).to.be.a("object");
+	describe("getCommand()", () => {
+		it("gets a mocked command", () => {
+			expect(factory.getCommand(commandName)).to.be.a("object");
 		});
-		
+
+		it("gets a mocked command - lowercase", () => {
+			expect(factory.getCommand(commandName.toLowerCase())).to.be.a("object");
+		});
+
+		it("gets a mocked command - uppercase", () => {
+			expect(factory.getCommand(commandName.toUpperCase())).to.be.a("object");
+		});
+
 		it("gets a mocked command by it's aliases", () => {
 			aliases.forEach(alias => {
 				expect(factory.getCommand(alias)).to.be.a("object");
 			});
 		});
-    });
+	});
 });


### PR DESCRIPTION
- Added `aliases` field to `CommandOptions` and `getAliases()` method to `Command`
- Added the aliases "codeblock" and "cb" to the codeblocks command
- Load aliases to the commands object in CommandFactory
- Created tests for aliases behaviour on `CommandFactoryTest.ts`