### PR TITLE
Fix missing access bug

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,9 +22,11 @@ const client = new Client();
 				client.on(handlerInstance.getEvent(), handlerInstance.handle);
 			});
 
-			const authChannel = await client.channels.fetch(AUTHENTICATION_MESSAGE_CHANNEL) as TextChannel;
+			if (process.env.NODE_ENV === "production") {
+				const authChannel = await client.channels.fetch(AUTHENTICATION_MESSAGE_CHANNEL) as TextChannel;
 
-			await authChannel.messages.fetch(AUTHENTICATION_MESSAGE_ID);
+				await authChannel.messages.fetch(AUTHENTICATION_MESSAGE_ID);
+			}
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import {Client, TextChannel} from "discord.js";
 import getFilesInDirectory from "./utils/getFilesInDirectory";
-import { handlers_directory, AUTHENTICATION_MESSAGE_CHANNEL, AUTHENTICATION_MESSAGE_ID } from "./config.json";
+import { handlers_directory, AUTHENTICATION_MESSAGE_CHANNEL, AUTHENTICATION_MESSAGE_ID, PRODUCTION_ENV } from "./config.json";
 
 const client = new Client();
 
@@ -22,7 +22,7 @@ const client = new Client();
 				client.on(handlerInstance.getEvent(), handlerInstance.handle);
 			});
 
-			if (process.env.NODE_ENV === "production") {
+			if (process.env.NODE_ENV === PRODUCTION_ENV) {
 				const authChannel = await client.channels.fetch(AUTHENTICATION_MESSAGE_CHANNEL) as TextChannel;
 
 				await authChannel.messages.fetch(AUTHENTICATION_MESSAGE_ID);

--- a/src/config.json
+++ b/src/config.json
@@ -3,6 +3,7 @@
     "MEMBER_ROLE": "592088198746996768",
     "AUTHENTICATION_MESSAGE_ID": "592316062796873738",
     "AUTHENTICATION_MESSAGE_CHANNEL": "592087564295471105",
+    "PRODUCTION_ENV": "production",
     "commands_directory": "commands",
     "handlers_directory": "event/handlers",
     "rules": [


### PR DESCRIPTION
Authentication message and channel now are only cached when `NODE_ENV` is `PRODUCTION_ENV`.