### PR TITLE
Rework InstantAnswerService

### DIFF
--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -22,7 +22,7 @@ class SearchCommand extends Command {
 				const InstantAnswer = InstantAnswerService.getInstance();
 				const res = await InstantAnswer.query(args.join("+"));
 
-				if (res) {
+				if (res !== null) {
 					const [baseURL] = res.url.match(/[a-z]*\.[a-z]*(\.[a-z]*)*/) || [];
 
 					embed.setTitle(res.heading);

--- a/src/services/InstantAnswerService.ts
+++ b/src/services/InstantAnswerService.ts
@@ -17,7 +17,7 @@ class InstantAnswerService {
 		return this.instance;
 	}
 
-	async query(query: string): Promise<InstantAnswer|null> {
+	async query(query: string): Promise<InstantAnswer | null> {
 		const url = `https://api.duckduckgo.com/?q=${query}&format=json&t=codesupport-discord-bot`;
 		const { status, data } = await axios.get(url);
 

--- a/src/services/InstantAnswerService.ts
+++ b/src/services/InstantAnswerService.ts
@@ -17,28 +17,32 @@ class InstantAnswerService {
 		return this.instance;
 	}
 
-	async query(query: string): Promise<InstantAnswer> {
+	async query(query: string): Promise<InstantAnswer|null> {
 		const url = `https://api.duckduckgo.com/?q=${query}&format=json&t=codesupport-discord-bot`;
 		const { status, data } = await axios.get(url);
 
-		if (status === 200 && data.Heading !== "") {
-			const [language] = INSTANT_ANSWER_HIGHLIGHTS.map(highlight =>
-				data.Heading.toLowerCase().includes(highlight) && highlight
-			);
+		if (status === 200) {
+			if (data.Heading !== "") {
+				const [language] = INSTANT_ANSWER_HIGHLIGHTS.map(highlight =>
+					data.Heading.toLowerCase().includes(highlight) && highlight
+				);
 
-			const description = data.AbstractText
-				.replace(/<code>/g, `\`\`\`${language}\n`)
-				.replace(/<\/code>/g, "```")
-				.replace(/<\/?[^>]+(>|$)/g, "")
-				.replace(/&#x27;/g, "\"")
-				.replace(/&lt;/g, "<")
-				.replace(/&gt;/g, ">");
+				const description = data.AbstractText
+					.replace(/<code>/g, `\`\`\`${language}\n`)
+					.replace(/<\/code>/g, "```")
+					.replace(/<\/?[^>]+(>|$)/g, "")
+					.replace(/&#x27;/g, "\"")
+					.replace(/&lt;/g, "<")
+					.replace(/&gt;/g, ">");
 
-			return {
-				heading: data.Heading,
-				description,
-				url: data.AbstractURL
-			};
+				return {
+					heading: data.Heading,
+					description,
+					url: data.AbstractURL
+				};
+			}
+
+			return null;
 		} else {
 			throw new Error("There was a problem with the DuckDuckGo API.");
 		}

--- a/test/commands/SearchCommandTest.ts
+++ b/test/commands/SearchCommandTest.ts
@@ -61,10 +61,10 @@ describe("SearchCommand", () => {
 			expect(embed.description).to.equal("You must define a search query.");
 		});
 
-		it("states it can not query duckduckgo if the result isnt found", async () => {
+		it("states it can not query duckduckgo if the result isn't found", async () => {
 			const messageMock = sandbox.stub(message.channel, "send");
 
-			sandbox.stub(instantAnswer, "query");
+			sandbox.stub(instantAnswer, "query").resolves(null);
 
 			await command.run(message, ["thisruledoesnotexist"]);
 


### PR DESCRIPTION
# Rework InstantAnswerService
## Summary
Currently when the `InstantAnswerService` returns no results the logic is set so that an exception is thrown, and the bot returns a message similar to "there was an error". Instead if no results are returned from DDG we want it to display "no results" rather than the aforementioned message as the previous message gives off the feeling something programmatically went wrong, when in fact, it did not.

### Changes
This PR changes `InstantAnswerService` to return `null` when no results have been found. This is also changed in `SearchCommand` to handle a `null` value being returned.