### PR TITLE
Support Use of .env Files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DISCORD_TOKEN=exampleToken

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 build/
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This repository contains the code for the CodeSupport Discord Bot. The project i
 2. Build the source code with `npm run build`
 3. Start the Discord bot with `npm start`
    - You will need to supply the `DISCORD_TOKEN` environment variable
+ 
+If you would like to use a `.env` file for storing your environment variables please create it in the root of the project.
 
 ## Structure
 - All source code lives inside `src/`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains the code for the CodeSupport Discord Bot. The project i
 ### Production
 - [Discord.js](https://www.npmjs.com/package/discord.js)
 - [Axios](https://www.npmjs.com/package/axios)
+- [dotenv](https://www.npmjs.com/package/dotenv)
 
 ### Development
 - [TypeScript](https://www.npmjs.com/package/typescript)

--- a/package-lock.json
+++ b/package-lock.json
@@ -654,6 +654,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/codesupport/discord-bot#readme",
   "dependencies": {
     "axios": "^0.19.2",
-    "discord.js": "^12.2.0"
+    "discord.js": "^12.2.0",
+    "dotenv": "^8.2.0"
   },
   "devDependencies": {
     "@types/assert": "^1.4.6",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,15 @@
-import {Client, TextChannel} from "discord.js";
+import { Client, TextChannel } from "discord.js";
+import { config as env } from "dotenv";
 import getFilesInDirectory from "./utils/getFilesInDirectory";
 import { handlers_directory, AUTHENTICATION_MESSAGE_CHANNEL, AUTHENTICATION_MESSAGE_ID, PRODUCTION_ENV } from "./config.json";
 
 const client = new Client();
+
+if (process.env.NODE_ENV !== PRODUCTION_ENV) {
+	env({
+		path: "../.env"
+	});
+}
 
 (async () => {
 	if (process.env.DISCORD_TOKEN) {


### PR DESCRIPTION
A much-requested feature has been for us to support `.env` files, I didn't really get the point of it since we only have one, however, with the TwitterService I'm working on it will require an additional four. This will make environment variables easier to work with.

#### Overview
- Installed dotenv
- Added `.env` to the `.gitignore`
- Specified non-production environments to use `.env` file (not required, however)
- Added to README and explained where to create the file