### PR TITLE
Fix unhandled TypeError "Cannot read property 'toLowerCase' of undefined"

### DIFF
--- a/src/event/handlers/CommandParserHandler.ts
+++ b/src/event/handlers/CommandParserHandler.ts
@@ -25,6 +25,8 @@ class CommandParserHandler extends EventHandler {
 			const args = message.content.replace("?", "").split(" ");
 			const trigger = args.shift() || args[0];
 
+			if (!trigger) return;
+
 			/* eslint-disable */
 			if (this.commandFactory.commandExists(trigger)) {
 				const command = this.commandFactory.getCommand(trigger);

--- a/test/event/handlers/CommandParserHandlerTest.ts
+++ b/test/event/handlers/CommandParserHandlerTest.ts
@@ -9,6 +9,7 @@ import CommandFactory from "../../../src/factories/CommandFactory";
 import CommandParserHandler from "../../../src/event/handlers/CommandParserHandler";
 import * as getConfigValue from "../../../src/utils/getConfigValue";
 import { COMMAND_PREFIX } from "../../../src/config.json";
+import Command from "../../../src/abstracts/Command";
 
 describe("CommandParserHandler", () => {
 	describe("constructor()", () => {
@@ -90,6 +91,23 @@ describe("CommandParserHandler", () => {
 			await handler.handle(message);
 
 			expect(runCommandMock.called).to.be.false;
+		});
+
+		it("should not throw error if message consists in command prefix", async () => {
+			const message = discordMock.getMessage();
+
+			message.content = COMMAND_PREFIX;
+			message.channel.id = "fake-bot-enabled-channel-id";
+
+			let errorWasThrown = false;
+
+			try {
+				await handler.handle(message);
+			} catch (error) {
+				errorWasThrown = true;
+			}
+
+			expect(errorWasThrown).to.be.false;
 		});
 
 		it("should run command", async () => {


### PR DESCRIPTION
This error happened when a message consisting only of a `?` (our Command prefix) was sent. After `CommandParserHandler`'s parsing, `undefined` would be passed to `CommandFactory.commandExists()`, causing it to throw this error. Just had to add an extra check inside `CommandParserHandler` to prevent this from happening. 