### PR TITLE
Don't let the bot quote other bots

### DIFF
--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -22,14 +22,17 @@ class MessagePreviewService {
 			if (callingMessage.guild?.available) {
 				const channel = callingMessage.guild.channels.cache.get(msgArray[1]) as TextChannel;
 				const messageToPreview = await channel.messages.fetch(msgArray[2]);
-				const embed = new MessageEmbed();
 
-				embed.setAuthor(messageToPreview.member?.nickname || messageToPreview.author.username, messageToPreview.author.avatarURL() || undefined, link);
-				embed.addField(`Called by ${callingMessage.member?.nickname || callingMessage.author.username}`, `[Click for context](${link})`);
-				embed.setDescription(`${messageToPreview.content}\n`);
-				embed.setColor(messageToPreview.member?.displayColor || "#FFFFFE");
+				if (!this.wasSentByABot(messageToPreview)) {
+					const embed = new MessageEmbed();
 
-				callingMessage.channel.send(embed);
+					embed.setAuthor(messageToPreview.member?.nickname || messageToPreview.author.username, messageToPreview.author.avatarURL() || undefined, link);
+					embed.addField(`Called by ${callingMessage.member?.nickname || callingMessage.author.username}`, `[Click for context](${link})`);
+					embed.setDescription(`${messageToPreview.content}\n`);
+					embed.setColor(messageToPreview.member?.displayColor || "#FFFFFE");
+
+					callingMessage.channel.send(embed);
+				}
 			}
 		}
 	}
@@ -40,6 +43,10 @@ class MessagePreviewService {
 
 	stripLink(link: string): string[] {
 		return link.substring(29).split("/");
+	}
+
+	wasSentByABot(message: Message): boolean {
+		return message.author?.bot;
 	}
 }
 

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -133,7 +133,7 @@ describe("MessagePreviewService", () => {
 			expect(messagePreview.wasSentByABot(message)).to.be.true;
 		});
 
-		it("should return false if message's authro isn't a bot", () => {
+		it("should return false if message's author isn't a bot", () => {
 			message.author.bot = false;
 
 			expect(messagePreview.wasSentByABot(message)).to.be.false;

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -37,7 +37,7 @@ describe("MessagePreviewService", () => {
 			const getsChannelMock = sandbox.stub(callingMessage.guild.channels.cache, "get").returns(channel);
 
 			sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
-			sandbox.stub(callingMessage.member, "displayColor").get(() => '#FFFFFF');
+			sandbox.stub(callingMessage.member, "displayColor").get(() => "#FFFFFF");
 			sandbox.stub(callingMessage.channel, "send");
 
 			await messagePreview.generatePreview(link, callingMessage);
@@ -50,7 +50,7 @@ describe("MessagePreviewService", () => {
 			const sendsMessageMock = sandbox.stub(callingMessage.channel, "send");
 
 			sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
-			sandbox.stub(callingMessage.member, "displayColor").get(() => '#FFFFFF');
+			sandbox.stub(callingMessage.member, "displayColor").get(() => "#FFFFFF");
 
 			await messagePreview.generatePreview(link, callingMessage);
 
@@ -59,6 +59,24 @@ describe("MessagePreviewService", () => {
 
 		afterEach(() => {
 			sandbox.restore();
+		});
+	});
+
+	describe("verifyGuild()", () => {
+		const messagePreview = MessagePreviewService.getInstance();
+		const discordMock = new MockDiscord();
+		const message = discordMock.getMessage();
+
+		it("should return true if message's guild and provided guild id match", () => {
+			message.guild.id = "RANDOM_GUILD_ID";
+
+			expect(messagePreview.verifyGuild(message, "RANDOM_GUILD_ID")).to.be.true;
+		});
+
+		it("should return false if message's guild and provided guild id don't match", () => {
+			message.guild.id = "RANDOM_GUILD_ID";
+
+			expect(messagePreview.verifyGuild(message, "OTHER_GUILD_ID")).to.be.false;
 		});
 	});
 

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -57,6 +57,18 @@ describe("MessagePreviewService", () => {
 			expect(sendsMessageMock.calledOnce).to.be.true;
 		});
 
+		it("doesn't send preview message if it is a bot message", async () => {
+			const getsChannelMock = sandbox.stub(callingMessage.guild.channels.cache, "get").returns(channel);
+			const sendsMessageMock = sandbox.stub(callingMessage.channel, "send");
+
+			callingMessage.author.bot = true;
+
+			sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
+			sandbox.stub(callingMessage.member, "displayColor").get(() => "#FFFFFF");
+
+			expect(sendsMessageMock.called).to.be.false;
+		});
+
 		afterEach(() => {
 			sandbox.restore();
 		});
@@ -101,6 +113,30 @@ describe("MessagePreviewService", () => {
 
 		afterEach(() => {
 			sandbox.restore();
+		});
+	});
+
+	describe("wasSentByABot()", () => {
+		let message: Message;
+		let discordMock: MockDiscord;
+		let messagePreview: MessagePreviewService;
+
+		beforeEach(() => {
+			discordMock = new MockDiscord();
+			message = discordMock.getMessage();
+			messagePreview = MessagePreviewService.getInstance();
+		});
+
+		it("should return true if message's author is a bot", () => {
+			message.author.bot = true;
+
+			expect(messagePreview.wasSentByABot(message)).to.be.true;
+		});
+
+		it("should return false if message's authro isn't a bot", () => {
+			message.author.bot = false;
+
+			expect(messagePreview.wasSentByABot(message)).to.be.false;
 		});
 	});
 });


### PR DESCRIPTION
I implemented this with a check to `message.author.bot`, so the bot doesn't quote any other bot. However, if bot-quoting is desired, we can just compare to the bot's id instead.

Resolves #95