### PR TITLE
Escape Message Preview Links At Any Position In The Message Content

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: coverage
 on:
   push:
     branches:
-      - develop
+      - master
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -11,7 +11,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
 		const linkIndex = message.content.search(messageRegex);
 
-		if (linkIndex == -1) return;
+		if (linkIndex === -1) return;
 
 		const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
 		const linkContent = message.content.split(" ")[wordIndex];

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -9,6 +9,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 
 	async handle(message: Message): Promise<void> {
 		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
+
 		const linkIndex = message.content.search(messageRegex);
 
 		if (linkIndex === -1) return;
@@ -21,6 +22,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 		const link = message.content.replace(/app/, "").replace(/ptb\./, "").substring(linkIndex, linkIndex + 85);
 
 		const messagePreviewService = MessagePreviewService.getInstance();
+
 		await messagePreviewService.generatePreview(link, message);
 
 	}

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -9,7 +9,6 @@ class DiscordMessageLinkHandler extends EventHandler {
 
 	async handle(message: Message): Promise<void> {
 		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
-
 		const linkIndex = message.content.search(messageRegex);
 
 		if (linkIndex === -1) return;
@@ -24,7 +23,6 @@ class DiscordMessageLinkHandler extends EventHandler {
 		const messagePreviewService = MessagePreviewService.getInstance();
 
 		await messagePreviewService.generatePreview(link, message);
-
 	}
 }
 

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -11,10 +11,15 @@ class DiscordMessageLinkHandler extends EventHandler {
 		const messagePreviewService = MessagePreviewService.getInstance();
 		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
 
-		if (message.content.startsWith("!")) return;
-
 		if (message.content.match(messageRegex)) {
 			const linkIndex = message.content.search(messageRegex);
+
+			// Gets the position of the url from a string
+			const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
+			const linkContent = message.content.split(" ")[wordIndex];
+
+			if (linkContent.startsWith("<") && linkContent.endsWith(">")) return;
+
 			const link = message.content.replace(/app/, "").replace(/ptb\./, "").substring(linkIndex, linkIndex + 85);
 
 			await messagePreviewService.generatePreview(link, message);

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -9,21 +9,20 @@ class DiscordMessageLinkHandler extends EventHandler {
 
 	async handle(message: Message): Promise<void> {
 		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
+		const linkIndex = message.content.search(messageRegex);
 
-		if (message.content.match(messageRegex)) {
-			const linkIndex = message.content.search(messageRegex);
-			if (linkIndex == -1) return;
+		if (linkIndex == -1) return;
 
-			const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
-			const linkContent = message.content.split(" ")[wordIndex];
+		const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
+		const linkContent = message.content.split(" ")[wordIndex];
 
-			if (linkContent.startsWith("<") && linkContent.endsWith(">")) return;
+		if (linkContent.startsWith("<") && linkContent.endsWith(">")) return;
 
-			const link = message.content.replace(/app/, "").replace(/ptb\./, "").substring(linkIndex, linkIndex + 85);
+		const link = message.content.replace(/app/, "").replace(/ptb\./, "").substring(linkIndex, linkIndex + 85);
 
-			const messagePreviewService = MessagePreviewService.getInstance();
-			await messagePreviewService.generatePreview(link, message);
-		}
+		const messagePreviewService = MessagePreviewService.getInstance();
+		await messagePreviewService.generatePreview(link, message);
+
 	}
 }
 

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -8,11 +8,11 @@ class DiscordMessageLinkHandler extends EventHandler {
 	}
 
 	async handle(message: Message): Promise<void> {
-		const messagePreviewService = MessagePreviewService.getInstance();
 		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
 
 		if (message.content.match(messageRegex)) {
 			const linkIndex = message.content.search(messageRegex);
+			if (linkIndex == -1) return;
 
 			const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
 			const linkContent = message.content.split(" ")[wordIndex];
@@ -21,6 +21,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 
 			const link = message.content.replace(/app/, "").replace(/ptb\./, "").substring(linkIndex, linkIndex + 85);
 
+			const messagePreviewService = MessagePreviewService.getInstance();
 			await messagePreviewService.generatePreview(link, message);
 		}
 	}

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -14,7 +14,6 @@ class DiscordMessageLinkHandler extends EventHandler {
 		if (message.content.match(messageRegex)) {
 			const linkIndex = message.content.search(messageRegex);
 
-			// Gets the position of the url from a string
 			const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
 			const linkContent = message.content.split(" ")[wordIndex];
 

--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -6,7 +6,7 @@ class MessagePreviewService {
 	private static instance: MessagePreviewService;
 
 	/* eslint-disable */
-	private constructor() {}
+	private constructor() { }
 	/* eslint-enable */
 
 	static getInstance(): MessagePreviewService {
@@ -30,7 +30,7 @@ class MessagePreviewService {
 					const parsedContent = this.escapeHyperlinks(messageToPreview.content);
 
 					embed.setAuthor(this.getAuthorName(messageToPreview), messageToPreview.author.avatarURL() || undefined, link);
-					embed.setDescription(`**#${this.getChannelName(messageToPreview)}**\n\n${parsedContent}\n`);
+					embed.setDescription(`**<#${channel.id}>**\n\n${parsedContent}\n`);
 					embed.addField(FIELD_SPACER_CHAR, `[View Original Message](${link})`);
 					embed.setFooter(`Message sent at ${DateUtils.formatAsText(messageToPreview.createdAt)}`);
 					embed.setColor(messageToPreview.member?.displayColor || MEMBER_ROLE_COLOR);

--- a/test/event/handlers/DiscordMessageLinkHandlerTest.ts
+++ b/test/event/handlers/DiscordMessageLinkHandlerTest.ts
@@ -39,12 +39,25 @@ describe("DiscordMessageLinkHandler", () => {
 			expect(generatePreviewMock.called).to.be.true;
 		});
 
-		it("does not send a message if the message starts with a !", async () => {
+		it("does not send a message if the message starts with < and ends with >", async () => {
 			const message = discordMock.getMessage();
 			const channel = discordMock.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
-			message.content = "!https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982";
+			message.content = "<https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982>";
+			message.channel = channel;
+
+			await handler.handle(message);
+
+			expect(generatePreviewMock.called).to.be.false;
+		});
+
+		it("does not send a message if the url was escaped mid sentence", async () => {
+			const message = discordMock.getMessage();
+			const channel = discordMock.getTextChannel();
+			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
+
+			message.content = "placeholderText <https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982> placeholderText";
 			message.channel = channel;
 
 			await handler.handle(message);


### PR DESCRIPTION
This bugfix makes sure the discord message refrence url escape characters can be used anywhere.

Also `!link` has been changed to `<link>` to keep the discord bot consistent with discords methods