### PR TITLE
Remove bold markdown in embed

### DIFF
--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -30,21 +30,15 @@ class MessagePreviewService {
 					const parsedContent = this.escapeHyperlinks(messageToPreview.content);
 
 					embed.setAuthor(this.getAuthorName(messageToPreview), messageToPreview.author.avatarURL() || undefined, link);
-					embed.setDescription(`**<#${channel.id}>**\n\n${parsedContent}\n`);
+					embed.setDescription(`<#${channel.id}>\n\n${parsedContent}\n`);
 					embed.addField(FIELD_SPACER_CHAR, `[View Original Message](${link})`);
 					embed.setFooter(`Message sent at ${DateUtils.formatAsText(messageToPreview.createdAt)}`);
 					embed.setColor(messageToPreview.member?.displayColor || MEMBER_ROLE_COLOR);
 
-					callingMessage.channel.send(embed);
+					await callingMessage.channel.send(embed);
 				}
 			}
 		}
-	}
-
-	getChannelName(message: Message): string {
-		const textChannel = message.channel as TextChannel;
-
-		return textChannel.name;
 	}
 
 	escapeHyperlinks(content: string): string {


### PR DESCRIPTION
# Remove bold markdown in embed
## Summary
~~When using the discord message handler (message link displays the message in an embed) on mobile the bold markdown was actually stopping the channel link from being clickable.~~ This PR removes the bold formatting around the channel hyperlink. Along with that, this PR removes the now unused `getChannelName` method along with adding a missing await.

Edit: On second attempt it does seem as though clicking it on mobile does actually change the channel. Will however keep the PR open as the bold formatted channel name to me seems slightly off (this is not rendered on my laptop anyways), and there are a couple of other changes in here that i still think are valid.

## Example on mobile
![IMG_0675](https://user-images.githubusercontent.com/20248039/97789704-6f4b3980-1bba-11eb-93f9-cc08e4903027.jpg)
