### PR TITLE
Fix Raid Detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm test",
     "test": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts test/appTest.ts --exit",
+    "test:debug": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts test/appTest.ts --timeout 999999999 --exit",
     "lint": "eslint src --ext .js,.ts"
   },
   "repository": {

--- a/src/event/handlers/CommandParserHandler.ts
+++ b/src/event/handlers/CommandParserHandler.ts
@@ -3,6 +3,7 @@ import EventHandler from "../../abstracts/EventHandler";
 import CommandFactory from "../../factories/CommandFactory";
 import getConfigValue from "../../utils/getConfigValue";
 import { COMMAND_PREFIX } from "../../config.json";
+import GenericObject from "../../interfaces/GenericObject";
 
 class CommandParserHandler extends EventHandler {
 	private readonly commandFactory: CommandFactory;
@@ -16,7 +17,7 @@ class CommandParserHandler extends EventHandler {
 
 	handle = async (message: Message): Promise<void> => {
 		if (message.content.startsWith(COMMAND_PREFIX)) {
-			const BOTLESS_CHANNELS = getConfigValue("BOTLESS_CHANNELS");
+			const BOTLESS_CHANNELS = getConfigValue<GenericObject<string>>("BOTLESS_CHANNELS");
 
 			if (Object.values(BOTLESS_CHANNELS).includes(message.channel.id)) {
 				return;

--- a/src/interfaces/GenericObject.ts
+++ b/src/interfaces/GenericObject.ts
@@ -1,0 +1,5 @@
+interface GenericObject<T> {
+	[Key: string]: T;
+}
+
+export default GenericObject;

--- a/src/utils/getConfigValue.ts
+++ b/src/utils/getConfigValue.ts
@@ -1,11 +1,20 @@
 import config from "../config.json";
 
-function getKeyValue(key: string, obj: Record<string, any>) {
+export function getKeyValue<T>(key: string, obj: Record<string, any>): T {
+	if (key.includes(".")) {
+		const newKey = key.split(".");
+		const [newObj] = newKey;
+
+		delete newKey[0];
+
+		return getKeyValue(newKey.join(""), obj[newObj]);
+	}
+
 	return obj[key];
 }
 
-function getConfigValue(key: string) {
-	return getKeyValue(key, config);
+function getConfigValue<T>(key: string): T {
+	return getKeyValue<T>(key, config);
 }
 
 export default getConfigValue;

--- a/test/utils/getConfigValue.ts
+++ b/test/utils/getConfigValue.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import { getKeyValue } from "../../src/utils/getConfigValue";
+
+describe("getConfigValue()", () => {
+	describe("getKeyValue", () => {
+		it("returns the requested key's value", () => {
+			const data = {
+				test: 1
+			};
+
+			expect(getKeyValue<number>("test", data)).to.equal(data.test);
+		});
+
+		it("returns the requested key's value if not top level", () => {
+			const data = {
+				more_data: {
+					test: 1
+				}
+			};
+
+			expect(getKeyValue<number>("more_data.test", data)).to.equal(data.more_data.test);
+		});
+	});
+});


### PR DESCRIPTION
#### Overview
- Fixed raid detection handler
- Changed handler to kick members if detected as being apart of a raid
- Added new `GenericObject` to stop the use of `any`
- Fixed `getConfigValue` so it can support nested keys

Shoutout everyone who helped test this, you're amazing.