### PR TITLE
Support .mov files

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -39,7 +39,8 @@
         "png",
         "gif",
         "mp3",
-        "mp4"
+        "mp4",
+        "mov"
     ],
     "rules": [
         {


### PR DESCRIPTION
Adding support for `.mov` files because QuickTime Screen Recordings are exported as `.mov` and I am too lazy to convert them to `.mp4` to send in Discord. 😄 