### PR TITLE
Bulk deletion

### DIFF
--- a/src/abstracts/LogMessageDeleteHandler.ts
+++ b/src/abstracts/LogMessageDeleteHandler.ts
@@ -1,13 +1,13 @@
-import { Constants, MessageEmbed, Message, TextChannel } from "discord.js";
-import { LOG_CHANNEL_ID, EMBED_COLOURS } from "../../config.json";
-import EventHandler from "../../abstracts/EventHandler";
+import { MessageEmbed, Message, TextChannel } from "discord.js";
+import { LOG_CHANNEL_ID, EMBED_COLOURS } from "../config.json";
+import EventHandler from "./EventHandler";
 
-class LogMessageDeleteHandler extends EventHandler {
-	constructor() {
-		super(Constants.Events.MESSAGE_DELETE);
+abstract class LogMessageDeleteHandler extends EventHandler {
+	protected constructor(event: any) {
+		super(event);
 	}
 
-	async handle(message: Message): Promise<void> {
+	async sendLog(message: Message): Promise<void> {
 		if (message.content !== "") {
 			const embed = new MessageEmbed();
 

--- a/src/abstracts/LogMessageDeleteHandler.ts
+++ b/src/abstracts/LogMessageDeleteHandler.ts
@@ -3,10 +3,6 @@ import { LOG_CHANNEL_ID, EMBED_COLOURS } from "../config.json";
 import EventHandler from "./EventHandler";
 
 abstract class LogMessageDeleteHandler extends EventHandler {
-	protected constructor(event: any) {
-		super(event);
-	}
-
 	async sendLog(message: Message): Promise<void> {
 		if (message.content !== "") {
 			const embed = new MessageEmbed();

--- a/src/event/handlers/LogMessageBulkDeleteHandler.ts
+++ b/src/event/handlers/LogMessageBulkDeleteHandler.ts
@@ -1,0 +1,16 @@
+import { Collection, Constants, Message, Snowflake } from "discord.js";
+import LogMessageDeleteHandler from "../../abstracts/LogMessageDeleteHandler";
+
+class LogMessageBulkDeleteHandler extends LogMessageDeleteHandler {
+	constructor() {
+		super(Constants.Events.MESSAGE_BULK_DELETE);
+	}
+
+	async handle(messages: Collection<Snowflake, Message>): Promise<void> {
+		for (const message of messages.array()) {
+			await super.sendLog(message);
+		}
+	}
+}
+
+export default LogMessageBulkDeleteHandler;

--- a/src/event/handlers/LogMessageSingleDeleteHandler.ts
+++ b/src/event/handlers/LogMessageSingleDeleteHandler.ts
@@ -1,0 +1,14 @@
+import { Constants, Message } from "discord.js";
+import LogMessageDeleteHandler from "../../abstracts/LogMessageDeleteHandler";
+
+class LogMessageSingleDeleteHandler extends LogMessageDeleteHandler {
+	constructor() {
+		super(Constants.Events.MESSAGE_DELETE);
+	}
+
+	async handle(message: Message): Promise<void> {
+		await super.sendLog(message);
+	}
+}
+
+export default LogMessageSingleDeleteHandler;

--- a/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { Collection, Constants, Message, Snowflake } from "discord.js";
+import { SinonSandbox, createSandbox } from "sinon";
+import { CustomMocks } from "@lambocreeper/mock-discord.js";
+
+import EventHandler from "../../../src/abstracts/EventHandler";
+import MessageConfigOptions from "@lambocreeper/mock-discord.js/build/interfaces/MessageConfigOptions";
+import LogMessageBulkDeleteHandler from "../../../src/event/handlers/LogMessageBulkDeleteHandler";
+
+function messageFactory(amount: number, options: MessageConfigOptions | undefined = undefined) {
+	const collection = new Collection<Snowflake, Message>();
+
+	for (let i = 0; i < amount; i++) {
+		if (options) {
+			collection.set(i.toString(), CustomMocks.getMessage(options));
+		} else {
+			collection.set(i.toString(), CustomMocks.getMessage());
+		}
+	}
+
+	return collection;
+}
+
+describe("LogMessageDeleteHandler", () => {
+	describe("constructor()", () => {
+		it("creates a handler for MESSAGE_Delete", () => {
+			const handler = new LogMessageBulkDeleteHandler();
+
+			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_BULK_DELETE);
+		});
+	});
+
+	describe("handle()", () => {
+		let sandbox: SinonSandbox;
+		let handler: EventHandler;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+			handler = new LogMessageBulkDeleteHandler();
+		});
+
+		it("sends a message in logs channel when a message is deleted", async () => {
+			const sendLogMock = sandbox.stub(Collection.prototype, "find");
+
+			await handler.handle(messageFactory(1));
+
+			expect(sendLogMock.calledOnce).to.be.true;
+		});
+
+		it("sends messages in logs channel when multiple messages are deleted", async () => {
+			const sendLogMock = sandbox.stub(Collection.prototype, "find");
+
+			await handler.handle(messageFactory(5));
+
+			expect(sendLogMock.callCount).to.be.eq(5);
+		});
+
+		it("does not send a message in logs channel when message is deleted but content is empty - only image", async () => {
+			const sendLogMock = sandbox.stub(Collection.prototype, "find");
+
+			await handler.handle(messageFactory(1, {
+				content: ''
+			}));
+
+			expect(sendLogMock.calledOnce).to.be.false;
+		});
+
+		it("does not send a message in logs channel when multiple messages are deleted but content is empty - only image", async () => {
+			const sendLogMock = sandbox.stub(Collection.prototype, "find");
+
+			await handler.handle(messageFactory(5, {
+				content: ''
+			}));
+
+			expect(sendLogMock.calledOnce).to.be.false;
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+	});
+});
+

--- a/test/event/handlers/LogMessageSingleDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageSingleDeleteHandlerTest.ts
@@ -1,15 +1,15 @@
 import { expect } from "chai";
 import { Constants } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
-import { BaseMocks } from "@lambocreeper/mock-discord.js";
+import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
 import EventHandler from "../../../src/abstracts/EventHandler";
-import LogMessageUpdateHandler from "../../../src/event/handlers/LogMessageDeleteHandler";
+import LogMessageSingleDeleteHandler from "../../../src/event/handlers/LogMessageSingleDeleteHandler";
 
 describe("LogMessageDeleteHandler", () => {
 	describe("constructor()", () => {
 		it("creates a handler for MESSAGE_Delete", () => {
-			const handler = new LogMessageUpdateHandler();
+			const handler = new LogMessageSingleDeleteHandler();
 
 			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_DELETE);
 		});
@@ -21,14 +21,14 @@ describe("LogMessageDeleteHandler", () => {
 
 		beforeEach(() => {
 			sandbox = createSandbox();
-			handler = new LogMessageUpdateHandler();
+			handler = new LogMessageSingleDeleteHandler();
 		});
 
 		it("sends a message in logs channel when a message is deleted", async () => {
-			const message = BaseMocks.getMessage();
+			const message = CustomMocks.getMessage({
+				content: "message content"
+			});
 			const messageMock = sandbox.stub(message.guild.channels.cache, "find");
-
-			message.content = "message content";
 
 			await handler.handle(message);
 
@@ -36,10 +36,10 @@ describe("LogMessageDeleteHandler", () => {
 		});
 
 		it("does not send a message in logs channel when message is deleted but content is empty - only image", async () => {
-			const message = BaseMocks.getMessage();
+			const message = CustomMocks.getMessage({
+				content: ""
+			});
 			const messageMock = sandbox.stub(message.guild.channels.cache, "find");
-
-			message.content = "";
 
 			await handler.handle(message);
 


### PR DESCRIPTION
# Bulk deletion
Resolves #131 
## Summary
This PR adds a new handler for the bulk deletion event sent by discord. The logic for this handler is exactly the same as it is for the single message deletion, so shared logic was pulled out into a new base abstract class.

### Testing
To test this i first setup a dummy command that triggers the bulk deletion, I also entered a log channel id relevant to my test guild in the configuration file.

```ts
import {Message, TextChannel} from "discord.js";
import Command from "../abstracts/Command";

class TestCommand extends Command {
	constructor() {
		super(
			"del",
			"",
			{
				selfDestructing: false,
				aliases: ["del"]
			}
		);
	}

	async run(message: Message, args: string[]): Promise<void> {
		const channel = message.channel as TextChannel;
		// Or get messages from a specific channel
		// const channel = message.guild?.channels.resolve("<id>") as TextChannel;

		await channel.bulkDelete(5);
	}
}

export default TestCommand;
```

#### Results
<img width="308" alt="Screenshot 2021-01-08 at 18 46 25" src="https://user-images.githubusercontent.com/20248039/104052591-d94b1500-51e1-11eb-8e20-ea2b8a57fa05.png">

#### Note
This PR also cleans up some previous tests that were modifying `BaseMock` properties