### PR TITLE
LogMemberLeaveHandler

### DIFF
--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -1,6 +1,6 @@
 import { Constants, GuildMember, MessageEmbed, TextChannel } from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
-import { EMBED_COLOURS } from "../../config.json";
+import { EMBED_COLOURS, MEMBER_ROLE, LOG_CHANNEL_ID } from "../../config.json";
 import DateUtils from "../../utils/DateUtils";
 
 class LogMemberLeaveHandler extends EventHandler {
@@ -16,14 +16,9 @@ class LogMemberLeaveHandler extends EventHandler {
 		embed.addField("Join date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
 		embed.addField("Leave date", new Date(Date.now()).toLocaleString(), true);
 		embed.addField("Time elapsed", DateUtils.getFormattedTimeSinceEpoch(guildMember.joinedTimestamp!));
+		embed.addField("Authenticated", guildMember.roles.cache.has(MEMBER_ROLE) ? "True" : "False");
 
-		if (guildMember?.roles.cache.size > 1) {
-			embed.addField("Roles", `${guildMember.roles.cache.filter(role => role.id !== guildMember?.guild!.id).map(role => ` ${role.toString()}`)}`);
-		} else {
-			embed.addField("Roles", "No roles");
-		}
-
-		const logsChannel = guildMember.guild?.channels.cache.find(channel => channel.id === "772542546282807316") as TextChannel;
+		const logsChannel = guildMember.guild?.channels.cache.find(channel => channel.id === LOG_CHANNEL_ID) as TextChannel;
 
 		await logsChannel?.send({embed});
 	}

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -1,0 +1,32 @@
+import { Constants, GuildMember, MessageEmbed, TextChannel } from "discord.js";
+import EventHandler from "../../abstracts/EventHandler";
+import { EMBED_COLOURS } from "../../config.json";
+import DateUtils from "../../utils/DateUtils";
+
+class LogMemberLeaveHandler extends EventHandler {
+	constructor() {
+		super(Constants.Events.GUILD_MEMBER_REMOVE);
+	}
+
+	async handle(guildMember: GuildMember): Promise <void> {
+		const embed = new MessageEmbed();
+
+		embed.setTitle(`${guildMember.user.tag} left the server.`);
+		embed.setColor(EMBED_COLOURS.DEFAULT);
+		embed.addField("Join date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
+		embed.addField("Leave date", new Date(Date.now()).toLocaleString(), true);
+		embed.addField("Time elapsed", DateUtils.getFormattedTimeSinceEpoch(guildMember.joinedTimestamp!));
+
+		if (guildMember?.roles.cache.size > 1) {
+			embed.addField("Roles", `${guildMember.roles.cache.filter(role => role.id !== guildMember?.guild!.id).map(role => ` ${role.toString()}`)}`);
+		} else {
+			embed.addField("Roles", "No roles");
+		}
+
+		const logsChannel = guildMember.guild?.channels.cache.find(channel => channel.id === "772542546282807316") as TextChannel;
+
+		await logsChannel?.send({embed});
+	}
+}
+
+export default LogMemberLeaveHandler;

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -8,14 +8,15 @@ class LogMemberLeaveHandler extends EventHandler {
 		super(Constants.Events.GUILD_MEMBER_REMOVE);
 	}
 
-	async handle(guildMember: GuildMember): Promise <void> {
+	async handle(guildMember: GuildMember): Promise<void> {
 		const embed = new MessageEmbed();
 
-		embed.setTitle(`${guildMember.user.tag} left the server.`);
+		embed.setTitle("Member Left");
+		embed.setDescription(`User: <@${guildMember.user.id}>`);
 		embed.setColor(EMBED_COLOURS.DEFAULT);
-		embed.addField("Join date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
-		embed.addField("Leave date", new Date(Date.now()).toLocaleString(), true);
-		embed.addField("Time in server", DateUtils.getFormattedTimeSinceDate(guildMember.joinedTimestamp!, Date.now()));
+		embed.addField("Join Date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
+		embed.addField("Leave Date", new Date(Date.now()).toLocaleString(), true);
+		embed.addField("Time In Server", DateUtils.getFormattedTimeSinceDate(guildMember.joinedAt!, new Date(Date.now())));
 		embed.addField("Authenticated", guildMember.roles.cache.has(MEMBER_ROLE) ? "True" : "False");
 
 		const logsChannel = guildMember.guild?.channels.cache.find(channel => channel.id === LOG_CHANNEL_ID) as TextChannel;

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -15,7 +15,7 @@ class LogMemberLeaveHandler extends EventHandler {
 		embed.setColor(EMBED_COLOURS.DEFAULT);
 		embed.addField("Join date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
 		embed.addField("Leave date", new Date(Date.now()).toLocaleString(), true);
-		embed.addField("Time elapsed", DateUtils.getFormattedTimeSinceEpoch(guildMember.joinedTimestamp!));
+		embed.addField("Time in server", DateUtils.getFormattedTimeSinceDate(guildMember.joinedTimestamp!, Date.now()));
 		embed.addField("Authenticated", guildMember.roles.cache.has(MEMBER_ROLE) ? "True" : "False");
 
 		const logsChannel = guildMember.guild?.channels.cache.find(channel => channel.id === LOG_CHANNEL_ID) as TextChannel;

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -20,6 +20,39 @@ class DateUtils {
 
 		return `${time} on ${date.getDate()} ${month} ${date.getFullYear()}`;
 	}
+
+	static getFormattedTimeSinceEpoch(timeInMs: number): string {
+		let difference = Date.now() - timeInMs;
+
+		let daysDifference = Math.floor(difference / 1000 / 60 / 60 / 24);
+
+		difference -= daysDifference * 1000 * 60 * 60 * 24;
+
+		const hoursDifference = Math.floor(difference / 1000 / 60 / 60);
+
+		difference -= hoursDifference * 1000 * 60 * 60;
+
+		const minutesDifference = Math.floor(difference / 1000 / 60);
+
+		difference -= minutesDifference * 1000 * 60;
+
+		const secondDifference = Math.floor(difference / 1000);
+
+		const yearsDifference = Math.floor(daysDifference / 365.2422);
+
+		daysDifference -= yearsDifference * 365.2422;
+
+		let formattedString = "its been ";
+
+		if (yearsDifference > 0) formattedString += `${yearsDifference} years, `;
+		if (daysDifference > 0) formattedString += `${daysDifference} days, `;
+		if (hoursDifference > 0) formattedString += `${hoursDifference} hours, `;
+		if (minutesDifference > 0) formattedString += `${minutesDifference} minutes and `;
+
+		formattedString += `${secondDifference} seconds.`;
+
+		return formattedString;
+	}
 }
 
 export default DateUtils;

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -42,14 +42,14 @@ class DateUtils {
 
 		daysDifference -= yearsDifference * 365.2422;
 
-		let formattedString = "its been ";
+		let formattedString = "";
 
 		if (yearsDifference > 0) formattedString += `${yearsDifference} years, `;
 		if (daysDifference > 0) formattedString += `${daysDifference} days, `;
 		if (hoursDifference > 0) formattedString += `${hoursDifference} hours, `;
 		if (minutesDifference > 0) formattedString += `${minutesDifference} minutes and `;
 
-		formattedString += `${secondDifference} seconds.`;
+		formattedString += `${secondDifference} seconds`;
 
 		return formattedString;
 	}

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -21,25 +21,20 @@ class DateUtils {
 		return `${time} on ${date.getDate()} ${month} ${date.getFullYear()}`;
 	}
 
-	static getFormattedTimeSinceDate(startTimeMs: number, endTimeMs: number): string | null {
-		if (endTimeMs < startTimeMs) return null;
+	static getFormattedTimeSinceDate(startDate: Date, endDate: Date): string | null {
+		if (endDate.getTime() < startDate.getTime()) return null;
 
-		let difference = endTimeMs - startTimeMs;
-
+		let difference = endDate.getTime() - startDate.getTime();
 		let daysDifference = Math.floor(difference / 1000 / 60 / 60 / 24);
 
 		difference -= daysDifference * 1000 * 60 * 60 * 24;
-
 		const hoursDifference = Math.floor(difference / 1000 / 60 / 60);
 
 		difference -= hoursDifference * 1000 * 60 * 60;
-
 		const minutesDifference = Math.floor(difference / 1000 / 60);
 
 		difference -= minutesDifference * 1000 * 60;
-
 		const secondDifference = Math.floor(difference / 1000);
-
 		const yearsDifference = Math.floor(daysDifference / 365);
 
 		daysDifference -= yearsDifference * 365;

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -21,8 +21,10 @@ class DateUtils {
 		return `${time} on ${date.getDate()} ${month} ${date.getFullYear()}`;
 	}
 
-	static getFormattedTimeSinceEpoch(timeInMs: number): string {
-		let difference = Date.now() - timeInMs;
+	static getFormattedTimeSinceDate(startTimeMs: number, endTimeMs: number): string | null {
+		if (endTimeMs < startTimeMs) return null;
+
+		let difference = endTimeMs - startTimeMs;
 
 		let daysDifference = Math.floor(difference / 1000 / 60 / 60 / 24);
 
@@ -38,18 +40,18 @@ class DateUtils {
 
 		const secondDifference = Math.floor(difference / 1000);
 
-		const yearsDifference = Math.floor(daysDifference / 365.2422);
+		const yearsDifference = Math.floor(daysDifference / 365);
 
-		daysDifference -= yearsDifference * 365.2422;
+		daysDifference -= yearsDifference * 365;
 
 		let formattedString = "";
 
-		if (yearsDifference > 0) formattedString += `${yearsDifference} years, `;
-		if (daysDifference > 0) formattedString += `${daysDifference} days, `;
-		if (hoursDifference > 0) formattedString += `${hoursDifference} hours, `;
-		if (minutesDifference > 0) formattedString += `${minutesDifference} minutes and `;
+		if (yearsDifference > 0) formattedString += `${yearsDifference} ${yearsDifference > 1 ? "years" : "year"}, `;
+		if (daysDifference > 0) formattedString += `${daysDifference} ${daysDifference > 1 ? "days" : "day"}, `;
+		if (hoursDifference > 0) formattedString += `${hoursDifference} ${hoursDifference > 1 ? "hours" : "hour"}, `;
+		if (minutesDifference > 0) formattedString += `${minutesDifference} ${minutesDifference > 1 ? "minutes" : "minute"} and `;
 
-		formattedString += `${secondDifference} seconds`;
+		formattedString += `${secondDifference} ${secondDifference > 1 ? "seconds" : "second"}`;
 
 		return formattedString;
 	}

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -28,12 +28,15 @@ class DateUtils {
 		let daysDifference = Math.floor(difference / 1000 / 60 / 60 / 24);
 
 		difference -= daysDifference * 1000 * 60 * 60 * 24;
+
 		const hoursDifference = Math.floor(difference / 1000 / 60 / 60);
 
 		difference -= hoursDifference * 1000 * 60 * 60;
+
 		const minutesDifference = Math.floor(difference / 1000 / 60);
 
 		difference -= minutesDifference * 1000 * 60;
+
 		const secondDifference = Math.floor(difference / 1000);
 		const yearsDifference = Math.floor(daysDifference / 365);
 

--- a/test/event/handlers/LogMemberLeaveHandlerTest.ts
+++ b/test/event/handlers/LogMemberLeaveHandlerTest.ts
@@ -1,20 +1,12 @@
 import { expect } from "chai";
-import {ChannelManager, Collection, Constants, GuildChannelManager, GuildMemberRoleManager, Role} from "discord.js";
+import { Collection, Constants, GuildMemberRoleManager, Role } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
-import { MEMBER_ROLE, LOG_CHANNEL_ID } from "../../../src/config.json";
+import { MEMBER_ROLE } from "../../../src/config.json";
 
 import EventHandler from "../../../src/abstracts/EventHandler";
 import LogMemberLeaveHandler from "../../../src/event/handlers/LogMemberLeaveHandler";
 import DateUtils from "../../../src/utils/DateUtils";
-
-const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
-	"id": MEMBER_ROLE.toString(),
-	"name": "member"
-}, BaseMocks.getGuild())], [BaseMocks.getGuild().id, new Role(BaseMocks.getClient(), {
-	"id": BaseMocks.getGuild().id,
-	"name": "@everyone"
-}, BaseMocks.getGuild())]]);
 
 describe("LogMemberLeaveHandler", () => {
 	describe("constructor()", () => {
@@ -34,17 +26,22 @@ describe("LogMemberLeaveHandler", () => {
 			handler = new LogMemberLeaveHandler();
 		});
 
-		it.only("sends a message in logs channel when a member leaves", async () => {
+		it("sends a message in logs channel when a member leaves", async () => {
 			const message = CustomMocks.getMessage();
-			const messageMock = sandbox.stub(message.channel, "send");
+			const messageMock = sandbox.stub(message.guild!.channels.cache, "find");
 
 			const guildMember = CustomMocks.getGuildMember({joined_at: 1610478967732});
 
+			const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
+				"id": MEMBER_ROLE.toString(),
+				"name": "member"
+			}, BaseMocks.getGuild())], [BaseMocks.getGuild().id, new Role(BaseMocks.getClient(), {
+				"id": BaseMocks.getGuild().id,
+				"name": "@everyone"
+			}, BaseMocks.getGuild())]]);
+
 			sandbox.stub(DateUtils, "getFormattedTimeSinceDate").resolves("10 seconds");
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
-			sandbox.stub(GuildChannelManager.prototype, "cache").get(() => {
-				CustomMocks.getGuildChannel({id: LOG_CHANNEL_ID});
-			});
 
 			await handler.handle(guildMember);
 

--- a/test/event/handlers/LogMemberLeaveHandlerTest.ts
+++ b/test/event/handlers/LogMemberLeaveHandlerTest.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import {ChannelManager, Collection, Constants, GuildChannelManager, GuildMemberRoleManager, Role} from "discord.js";
+import { SinonSandbox, createSandbox } from "sinon";
+import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
+import { MEMBER_ROLE, LOG_CHANNEL_ID } from "../../../src/config.json";
+
+import EventHandler from "../../../src/abstracts/EventHandler";
+import LogMemberLeaveHandler from "../../../src/event/handlers/LogMemberLeaveHandler";
+import DateUtils from "../../../src/utils/DateUtils";
+
+const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
+	"id": MEMBER_ROLE.toString(),
+	"name": "member"
+}, BaseMocks.getGuild())], [BaseMocks.getGuild().id, new Role(BaseMocks.getClient(), {
+	"id": BaseMocks.getGuild().id,
+	"name": "@everyone"
+}, BaseMocks.getGuild())]]);
+
+describe("LogMemberLeaveHandler", () => {
+	describe("constructor()", () => {
+		it("creates a handler for GUILD_MEMBER_REMOVE)", () => {
+			const handler = new LogMemberLeaveHandler();
+
+			expect(handler.getEvent()).to.equal(Constants.Events.GUILD_MEMBER_REMOVE);
+		});
+	});
+
+	describe("handle()", () => {
+		let sandbox: SinonSandbox;
+		let handler: EventHandler;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+			handler = new LogMemberLeaveHandler();
+		});
+
+		it.only("sends a message in logs channel when a member leaves", async () => {
+			const message = CustomMocks.getMessage();
+			const messageMock = sandbox.stub(message.channel, "send");
+
+			const guildMember = CustomMocks.getGuildMember({joined_at: 1610478967732});
+
+			sandbox.stub(DateUtils, "getFormattedTimeSinceDate").resolves("10 seconds");
+			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
+			sandbox.stub(GuildChannelManager.prototype, "cache").get(() => {
+				CustomMocks.getGuildChannel({id: LOG_CHANNEL_ID});
+			});
+
+			await handler.handle(guildMember);
+
+			expect(messageMock.calledOnce).to.be.true;
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+	});
+});
+

--- a/test/utils/DateUtilsTest.ts
+++ b/test/utils/DateUtilsTest.ts
@@ -72,11 +72,20 @@ describe("DateUtils", () => {
 
 	describe("::getFormattedTimeSinceDate()", () => {
 		it("returns a formatted string that contains the difference between two dates", () => {
-			expect(DateUtils.getFormattedTimeSinceDate(new Date("01/12/2021 00:00:00").getTime(), new Date("01/15/2022 06:30:05").getTime())).to.equal("1 year, 3 days, 6 hours, 30 minutes and 5 seconds");
-		});
-	});
+			const expected = "1 year, 3 days, 6 hours, 30 minutes and 5 seconds";
+			const start = new Date("01/12/2021 00:00:00");
+			const end = new Date("01/15/2022 06:30:05");
+			const actual = DateUtils.getFormattedTimeSinceDate(start, end);
 
-	it("returns null if endTimeMs is earlier then startTimeMs", () => {
-		expect(DateUtils.getFormattedTimeSinceDate(Date.now() + 1800000, Date.now())).to.equal(null);
+			expect(actual).to.equal(expected);
+		});
+
+		it("returns null if endDate is earlier then startDate", () => {
+			const start = new Date(Date.now() + 1800000);
+			const end = new Date(Date.now());
+			const actual = DateUtils.getFormattedTimeSinceDate(start, end);
+
+			expect(actual).to.equal(null);
+		});
 	});
 });

--- a/test/utils/DateUtilsTest.ts
+++ b/test/utils/DateUtilsTest.ts
@@ -69,4 +69,14 @@ describe("DateUtils", () => {
 			expect(DateUtils.formatAsText(date)).to.equal("09:05 on 7 Feb 2010");
 		});
 	});
+
+	describe("::getFormattedTimeSinceDate()", () => {
+		it("returns a formatted string that contains the difference between two dates", () => {
+			expect(DateUtils.getFormattedTimeSinceDate(new Date("01/12/2021 00:00:00").getTime(), new Date("01/15/2022 06:30:05").getTime())).to.equal("1 year, 3 days, 6 hours, 30 minutes and 5 seconds");
+		});
+	});
+
+	it("returns null if endTimeMs is earlier then startTimeMs", () => {
+		expect(DateUtils.getFormattedTimeSinceDate(Date.now() + 1800000, Date.now())).to.equal(null);
+	});
 });


### PR DESCRIPTION
This pull request adds a handler for when a member leaves, it will send a message to the logs channel that states:
- When the user joined and left.
- How long the user stayed on the server.
- if the user was authenticated.

Besides that, it also adds a new `DateUtil` method called `getFormattedTimeSinceDate`:
- Takes in a `startDate: Date` and a `endDate: Date` as argument.
- returns a string that is formated as followed `# years, # days, # hours, # minutes and # seconds`.
- will not return certain parts of the string if value is `0`.
- will detect if output value is single `day` or multiple `days`.
- will return null when `endDate` is earlier then `startDate`.

![Knipsel](https://user-images.githubusercontent.com/62018777/104373072-a924ae80-5520-11eb-91a2-b249a9cdfc46.JPG)


