### PR TITLE
Change npm lint script to also lint the 'test' directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm test",
     "test": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts test/appTest.ts --exit",
     "test:debug": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts test/appTest.ts --timeout 999999999 --exit",
-    "lint": "eslint src --ext .js,.ts && eslint test --ext .js,.ts"
+    "lint": "eslint src test --ext .js,.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm test",
     "test": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts test/appTest.ts --exit",
     "test:debug": "ts-mocha test/**/*Test.ts test/**/**/*Test.ts test/appTest.ts --timeout 999999999 --exit",
-    "lint": "eslint src --ext .js,.ts"
+    "lint": "eslint src --ext .js,.ts && eslint test --ext .js,.ts"
   },
   "repository": {
     "type": "git",

--- a/test/MockCommand.ts
+++ b/test/MockCommand.ts
@@ -7,6 +7,6 @@ export default class MockCommand extends Command {
 	}
 
 	async run(message: Message, args: string[]): Promise<void> {
-
+		return;
 	}
 }

--- a/test/MockCommandWithAlias.ts
+++ b/test/MockCommandWithAlias.ts
@@ -13,6 +13,6 @@ export default class MockCommandWithAlias extends Command {
 	}
 
 	async run(message: Message, args: string[]): Promise<void> {
-
+		return;
 	}
 }

--- a/test/appTest.ts
+++ b/test/appTest.ts
@@ -47,7 +47,7 @@ describe("app", () => {
 	});
 
 	it("should bind handlers to events", async () => {
-		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [require("../MockHandler")]); // eslint-disable-line global-require
+		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [require("./MockHandler")]); // eslint-disable-line global-require
 		const onStub = sandbox.stub(Client.prototype, "on");
 
 		await app();

--- a/test/appTest.ts
+++ b/test/appTest.ts
@@ -47,8 +47,7 @@ describe("app", () => {
 	});
 
 	it("should bind handlers to events", async () => {
-		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [MockHandler]);
-
+		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [require("../MockHandler")]); // eslint-disable-line global-require
 		const onStub = sandbox.stub(Client.prototype, "on");
 
 		await app();

--- a/test/appTest.ts
+++ b/test/appTest.ts
@@ -31,7 +31,7 @@ describe("app", () => {
 	});
 
 	it("should login with the provided DISCORD_TOKEN", async () => {
-		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(() => []);
+		sandbox.stub(DirectoryUtils, "getFilesInDirectory");
 
 		await app();
 
@@ -39,7 +39,7 @@ describe("app", () => {
 	});
 
 	it("should look for handler files", async () => {
-		const getFilesStub = sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(() => []);
+		const getFilesStub = sandbox.stub(DirectoryUtils, "getFilesInDirectory");
 
 		await app();
 
@@ -47,7 +47,7 @@ describe("app", () => {
 	});
 
 	it("should bind handlers to events", async () => {
-		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [require("./MockHandler")]);
+		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [MockHandler]);
 
 		const onStub = sandbox.stub(Client.prototype, "on");
 

--- a/test/appTest.ts
+++ b/test/appTest.ts
@@ -47,7 +47,8 @@ describe("app", () => {
 	});
 
 	it("should bind handlers to events", async () => {
-		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [require("./MockHandler")]); // eslint-disable-line global-require
+		// eslint-disable-next-line global-require
+		sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [require("./MockHandler")]);
 		const onStub = sandbox.stub(Client.prototype, "on");
 
 		await app();

--- a/test/commands/ResourcesCommandTest.ts
+++ b/test/commands/ResourcesCommandTest.ts
@@ -6,7 +6,6 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import Command from "../../src/abstracts/Command";
 import ResourcesCommand from "../../src/commands/ResourcesCommand";
 
-
 describe("ResourcesCommand", () => {
 	describe("constructor()", () => {
 		it("creates a command called resources", () => {

--- a/test/event/handlers/DiscordMessageLinkHandlerTest.ts
+++ b/test/event/handlers/DiscordMessageLinkHandlerTest.ts
@@ -7,7 +7,6 @@ import EventHandler from "../../../src/abstracts/EventHandler";
 import MessagePreviewService from "../../../src/services/MessagePreviewService";
 import DiscordMessageLinkHandler from "../../../src/event/handlers/DiscordMessageLinkHandler";
 
-
 describe("DiscordMessageLinkHandler", () => {
 	describe("Constructor()", () => {
 		it("creates a handler for MESSAGE_CREATE", () => {

--- a/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
@@ -59,7 +59,7 @@ describe("LogMessageDeleteHandler", () => {
 			const sendLogMock = sandbox.stub(Collection.prototype, "find");
 
 			await handler.handle(messageFactory(1, {
-				content: ''
+				content: ""
 			}));
 
 			expect(sendLogMock.calledOnce).to.be.false;
@@ -69,7 +69,7 @@ describe("LogMessageDeleteHandler", () => {
 			const sendLogMock = sandbox.stub(Collection.prototype, "find");
 
 			await handler.handle(messageFactory(5, {
-				content: ''
+				content: ""
 			}));
 
 			expect(sendLogMock.calledOnce).to.be.false;

--- a/test/event/handlers/RaidDetectionHandlerTest.ts
+++ b/test/event/handlers/RaidDetectionHandlerTest.ts
@@ -7,7 +7,6 @@ import { RAID_SETTINGS, MOD_CHANNEL_ID } from "../../../src/config.json";
 import * as getConfigValue from "../../../src/utils/getConfigValue";
 import RaidDetectionHandler from "../../../src/event/handlers/RaidDetectionHandler";
 
-
 describe("RaidDetectionHandler", () => {
 	describe("constructor()", () => {
 		it("creates a handler for GUILD_MEMBER_ADD", () => {
@@ -36,6 +35,7 @@ describe("RaidDetectionHandler", () => {
 
 		it("removes member from joinQueue", done => {
 			const mockGuildMember = BaseMocks.getGuildMember();
+
 			sandbox.stub(getConfigValue, "default").returns(0.002);
 
 			handler.handle(mockGuildMember).then(() => {

--- a/test/factories/CommandFactoryTest.ts
+++ b/test/factories/CommandFactoryTest.ts
@@ -39,7 +39,8 @@ describe("CommandFactory", () => {
 			emptyFactory = new CommandFactory();
 
 			getFilesStub = sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [
-				require("../MockCommand"), require("../MockCommandWithAlias")
+				MockCommand,
+				MockCommandWithAlias
 			]);
 		});
 

--- a/test/factories/CommandFactoryTest.ts
+++ b/test/factories/CommandFactoryTest.ts
@@ -39,8 +39,8 @@ describe("CommandFactory", () => {
 			emptyFactory = new CommandFactory();
 
 			getFilesStub = sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [
-				MockCommand,
-				MockCommandWithAlias
+				require("../MockCommand"), // eslint-disable-line global-require
+				require("../MockCommandWithAlias") // eslint-disable-line global-require
 			]);
 		});
 

--- a/test/factories/CommandFactoryTest.ts
+++ b/test/factories/CommandFactoryTest.ts
@@ -39,8 +39,11 @@ describe("CommandFactory", () => {
 			emptyFactory = new CommandFactory();
 
 			getFilesStub = sandbox.stub(DirectoryUtils, "getFilesInDirectory").callsFake(async () => [
-				require("../MockCommand"), // eslint-disable-line global-require
-				require("../MockCommandWithAlias") // eslint-disable-line global-require
+				// eslint-disable-next-line global-require
+				require("../MockCommand"),
+
+				// eslint-disable-next-line global-require
+				require("../MockCommandWithAlias")
 			]);
 		});
 

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -28,13 +28,13 @@ describe("MessagePreviewService", () => {
 
 			messagePreview = MessagePreviewService.getInstance();
 
-			let guild = CustomMocks.getGuild({
+			const guild = CustomMocks.getGuild({
 				id: "guild-id",
 				channels: []
 			});
 
 			channel = CustomMocks.getTextChannel({
-				id: '518817917438001152'
+				id: "518817917438001152"
 			}, guild);
 
 			callingMessage = CustomMocks.getMessage({}, {

--- a/test/services/TwitterServiceTest.ts
+++ b/test/services/TwitterServiceTest.ts
@@ -36,8 +36,8 @@ describe("TwitterService", () => {
 			channel = BaseMocks.getTextChannel();
 		});
 
-		it("streams twitter for statuses/filter on the codesupportdev account", (done) => {
-			let eventEmitter = new EventEmitter();
+		it("streams twitter for statuses/filter on the codesupportdev account", done => {
+			const eventEmitter = new EventEmitter();
 
 			const streamSpy = sandbox.stub(Twitter.prototype, "stream").returns(eventEmitter);
 			const send = sandbox.stub(channel, "send");
@@ -55,11 +55,11 @@ describe("TwitterService", () => {
 					retweeted_status: {
 						id_str: "1244"
 					}
-				}
+				};
 
 				eventEmitter.on("data", () => {
 					done();
-				})
+				});
 
 				eventEmitter.emit("data", tweet);
 				expect(streamSpy.calledOnce).to.be.true;

--- a/test/utils/getEnvironmentVariableTest.ts
+++ b/test/utils/getEnvironmentVariableTest.ts
@@ -8,7 +8,7 @@ describe("getEnvironmentVariable", () => {
 	});
 
 	it("should throw error if variable is not set", () => {
-		expect(() => getEnvironmentVariable("FAKE_VAR")).to.throw('The environment variable "FAKE_VAR" is not set.');
+		expect(() => getEnvironmentVariable("FAKE_VAR")).to.throw("The environment variable \"FAKE_VAR\" is not set.");
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
Currently, the lint script in package.json only lints the 'src' directory, and not the 'test' directory. I'm proposing to have eslint lint both directories, so we also hold our unit tests to eslint's standard. 

Doing this does introduce 18 eslint problems, which have been fixed in updates to this PR.