### PR TITLE
GhostPingHandler now adds relevant info for deleted replies.

### DIFF
--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -32,15 +32,16 @@ class GhostPingHandler extends EventHandler {
 				embed.setTitle("Ghost Ping Detected!");
 
 				if (repliedToUser !== null && repliedToUser !== undefined) {
-					embed.addField("Author - Reply to", `<@${message.author.id}> - <@${repliedToUser.id}>`);
+					embed.addField("Author", message.author, true);
+					embed.addField("Reply to", repliedToUser, true);
 				} else {
 					embed.addField("Author", message.author);
 				}
 
 				embed.addField("Message", message.content);
 
-				if (repliedToMessage !== null && repliedToMessage !== undefined) {
-					embed.addField("Message replied to", `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`);
+				if (repliedToMessage !== null && repliedToMessage !== undefined && repliedToMessage !== null) {
+					embed.addField("Message replied to", `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`, true);
 				}
 
 				embed.setFooter(`Message sent at ${DateUtils.formatAsText(message.createdAt)}`);

--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -25,7 +25,6 @@ class GhostPingHandler extends EventHandler {
 
 					if (repliedToChannel instanceof TextChannel) {
 						repliedToMessage = await repliedToChannel.messages.fetch(message.reference.messageID);
-						console.log(repliedToMessage);
 						repliedToUser = repliedToMessage?.author;
 					}
 				}

--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -1,4 +1,4 @@
-import { Constants, MessageEmbed, Message } from "discord.js";
+import { Constants, MessageEmbed, Message, User, TextChannel } from "discord.js";
 import { EMBED_COLOURS } from "../../config.json";
 import DateUtils from "../../utils/DateUtils";
 import EventHandler from "../../abstracts/EventHandler";
@@ -17,9 +17,28 @@ class GhostPingHandler extends EventHandler {
 
 				const embed = new MessageEmbed();
 
+				let repliedToMessage : Message|null|undefined = null;
+				let repliedToUser: User|null|undefined = null;
+
+				if (message.reference?.messageID && message.reference.guildID === message.guild?.id) {
+					const repliedToChannel = message.guild.channels.resolve(message.reference.channelID);
+
+					if (repliedToChannel instanceof TextChannel) {
+						repliedToMessage = await repliedToChannel.messages.fetch(message.reference.messageID);
+						console.log(repliedToMessage);
+						repliedToUser = repliedToMessage?.author;
+					}
+				}
+
 				embed.setTitle("Ghost Ping Detected!");
 				embed.addField("Author", message.author);
 				embed.addField("Message", message.content);
+				if (repliedToUser !== null && repliedToUser !== undefined) {
+					embed.addField("Reply to", repliedToUser);
+				}
+				if (repliedToMessage !== null && repliedToMessage !== undefined && repliedToMessage !== null) {
+					embed.addField("Message replied to", `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`);
+				}
 				embed.setFooter(`Message sent at ${DateUtils.formatAsText(message.createdAt)}`);
 				embed.setColor(EMBED_COLOURS.DEFAULT);
 

--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -17,8 +17,8 @@ class GhostPingHandler extends EventHandler {
 
 				const embed = new MessageEmbed();
 
-				let repliedToMessage : Message|null|undefined = null;
-				let repliedToUser: User|null|undefined = null;
+				let repliedToMessage : Message | null | undefined = null;
+				let repliedToUser: User | null | undefined = null;
 
 				if (message.reference?.messageID && message.reference.guildID === message.guild?.id) {
 					const repliedToChannel = message.guild.channels.resolve(message.reference.channelID);

--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -30,14 +30,19 @@ class GhostPingHandler extends EventHandler {
 				}
 
 				embed.setTitle("Ghost Ping Detected!");
-				embed.addField("Author", message.author);
-				embed.addField("Message", message.content);
+
 				if (repliedToUser !== null && repliedToUser !== undefined) {
-					embed.addField("Reply to", repliedToUser);
+					embed.addField("Author - Reply to", `<@${message.author.id}> - <@${repliedToUser.id}>`);
+				} else {
+					embed.addField("Author", message.author);
 				}
+
+				embed.addField("Message", message.content);
+
 				if (repliedToMessage !== null && repliedToMessage !== undefined && repliedToMessage !== null) {
 					embed.addField("Message replied to", `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`);
 				}
+
 				embed.setFooter(`Message sent at ${DateUtils.formatAsText(message.createdAt)}`);
 				embed.setColor(EMBED_COLOURS.DEFAULT);
 

--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -39,7 +39,7 @@ class GhostPingHandler extends EventHandler {
 
 				embed.addField("Message", message.content);
 
-				if (repliedToMessage !== null && repliedToMessage !== undefined && repliedToMessage !== null) {
+				if (repliedToMessage !== null && repliedToMessage !== undefined) {
 					embed.addField("Message replied to", `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`);
 				}
 

--- a/test/event/handlers/GhostPingHandlerTest.ts
+++ b/test/event/handlers/GhostPingHandlerTest.ts
@@ -121,7 +121,7 @@ describe("GhostPingHandler", () => {
 
 			expect(sentEmbed).to.be.an.instanceOf(MessageEmbed);
 			if (sentEmbed instanceof MessageEmbed) {
-				const replyToField = sentEmbed.fields.find(field => field.name === "Reply to");
+				const replyToField = sentEmbed.fields.find(field => field.name === "Author - Reply to");
 
 				expect(replyToField).to.not.be.null;
 

--- a/test/event/handlers/GhostPingHandlerTest.ts
+++ b/test/event/handlers/GhostPingHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants, MessageMentions } from "discord.js";
+import { Collection, Constants, Guild, Message, MessageEmbed, MessageMentions, MessageReference } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -90,6 +90,46 @@ describe("GhostPingHandler", () => {
 
 			await handler.handle(message);
 			expect(messageMock.called).to.be.true;
+		});
+
+		it("provides additional info if message is a reply to another message", async () => {
+			const message = CustomMocks.getMessage({guild: CustomMocks.getGuild()});
+			const messageMock = sandbox.stub(message.channel, "send");
+			const channelMock = CustomMocks.getTextChannel();
+			const repliedToMessage = CustomMocks.getMessage({	id: "328194044587147280", guild: CustomMocks.getGuild()});
+			const resolveChannelStub = sandbox.stub(message.guild.channels, "resolve").returns(channelMock);
+			const fetchMessageStub = sandbox.stub(channelMock.messages, "fetch").returns(Promise.resolve(repliedToMessage));
+			const author = CustomMocks.getUser();
+
+			message.author = author;
+			message.mentions = new MessageMentions(message, [CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			message.guild.id = "328194044587147279";
+			message.content = "this is a reply";
+			message.reference = {
+				channelID: "328194044587147278",
+				guildID: "328194044587147279",
+				messageID: "328194044587147280"
+			};
+
+			repliedToMessage.channel = CustomMocks.getTextChannel({ id: "328194044587147278"});
+
+			await handler.handle(message);
+			expect(messageMock.called).to.be.true;
+			expect(resolveChannelStub.called).to.be.true;
+			expect(fetchMessageStub.called).to.be.true;
+			const sentEmbed = messageMock.getCall(0).args[0];
+
+			expect(sentEmbed).to.be.an.instanceOf(MessageEmbed);
+			if (sentEmbed instanceof MessageEmbed) {
+				const replyToField = sentEmbed.fields.find(field => field.name === "Reply to");
+
+				expect(replyToField).to.not.be.null;
+
+				const messageLinkField = sentEmbed.fields.find(field => field.name === "Message replied to");
+
+				expect(messageLinkField).to.not.be.null;
+				expect(messageLinkField.value).to.equal("https://discord.com/channels/328194044587147279/328194044587147278/328194044587147280");
+			}
 		});
 
 		afterEach(() => {

--- a/test/event/handlers/GhostPingHandlerTest.ts
+++ b/test/event/handlers/GhostPingHandlerTest.ts
@@ -121,7 +121,7 @@ describe("GhostPingHandler", () => {
 
 			expect(sentEmbed).to.be.an.instanceOf(MessageEmbed);
 			if (sentEmbed instanceof MessageEmbed) {
-				const replyToField = sentEmbed.fields.find(field => field.name === "Author - Reply to");
+				const replyToField = sentEmbed.fields.find(field => field.name === "Reply to");
 
 				expect(replyToField).to.not.be.null;
 


### PR DESCRIPTION
The GhostPingHandler will now check if a deleted message is a reply to another message, and if so, add info on who was replied to and which message was replied to. This adds useful info that provides additional context for deleted replies. and directly addresses issue #133.

A notification of a deleted reply now looks like this:
![image](https://user-images.githubusercontent.com/28660369/104666571-80451a80-56d4-11eb-80f5-3e9a1ddf45ea.png)

A unit test has also been included to verify that reply info is added to the embed correctly.
![image](https://user-images.githubusercontent.com/28660369/104670941-167d3e80-56dd-11eb-99c4-631e3a76d228.png)
