### PR TITLE
LogMemberLeave update/not send on raid

### DIFF
--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -1,6 +1,6 @@
-import { Constants, GuildMember, MessageEmbed, TextChannel } from "discord.js";
+import { Constants, GuildAuditLogs, GuildMember, MessageEmbed, TextChannel } from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
-import { EMBED_COLOURS, MEMBER_ROLE, LOG_CHANNEL_ID } from "../../config.json";
+import { EMBED_COLOURS, MEMBER_ROLE, LOG_CHANNEL_ID, RAID_SETTINGS } from "../../config.json";
 import DateUtils from "../../utils/DateUtils";
 
 class LogMemberLeaveHandler extends EventHandler {
@@ -9,6 +9,16 @@ class LogMemberLeaveHandler extends EventHandler {
 	}
 
 	async handle(member: GuildMember): Promise<void> {
+		const logs = await member.guild.fetchAuditLogs({ limit: RAID_SETTINGS.MAX_QUEUE_SIZE + 2, type: GuildAuditLogs.Actions.MEMBER_KICK });
+
+		const isInLogs = logs.entries.find(log => {
+			const target = log.target as GuildMember;
+
+			return target.id === member.id && log.reason === "Detected as part of a raid.";
+		});
+
+		if (isInLogs) return;
+
 		const embed = new MessageEmbed();
 
 		embed.setTitle("Member Left");

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -8,20 +8,20 @@ class LogMemberLeaveHandler extends EventHandler {
 		super(Constants.Events.GUILD_MEMBER_REMOVE);
 	}
 
-	async handle(guildMember: GuildMember): Promise<void> {
+	async handle(member: GuildMember): Promise<void> {
 		const embed = new MessageEmbed();
 
 		embed.setTitle("Member Left");
-		embed.setDescription(`User: <@${guildMember.user.id}>`);
+		embed.setDescription(`User: ${member.user.username}#${member.user.discriminator} (${member.user.id})`);
 		embed.setColor(EMBED_COLOURS.DEFAULT);
-		embed.addField("Join Date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
+		embed.addField("Join Date", new Date(member.joinedTimestamp!).toLocaleString(), true);
 		embed.addField("Leave Date", new Date(Date.now()).toLocaleString(), true);
-		embed.addField("Time In Server", DateUtils.getFormattedTimeSinceDate(guildMember.joinedAt!, new Date(Date.now())));
-		embed.addField("Authenticated", guildMember.roles.cache.has(MEMBER_ROLE) ? "True" : "False");
+		embed.addField("Time In Server", DateUtils.getFormattedTimeSinceDate(member.joinedAt!, new Date(Date.now())));
+		embed.addField("Authenticated", member.roles.cache.has(MEMBER_ROLE) ? "True" : "False");
 
-		const logsChannel = guildMember.guild?.channels.cache.find(channel => channel.id === LOG_CHANNEL_ID) as TextChannel;
+		const logsChannel = member.guild?.channels.cache.find(channel => channel.id === LOG_CHANNEL_ID) as TextChannel;
 
-		await logsChannel?.send({embed});
+		await logsChannel?.send({ embed });
 	}
 }
 

--- a/test/event/handlers/LogMemberLeaveHandlerTest.ts
+++ b/test/event/handlers/LogMemberLeaveHandlerTest.ts
@@ -26,7 +26,7 @@ describe("LogMemberLeaveHandler", () => {
 			handler = new LogMemberLeaveHandler();
 		});
 
-		it.only("sends a message in logs channel when a member leaves", async () => {
+		it("sends a message in logs channel when a member leaves", async () => {
 			const message = CustomMocks.getMessage();
 
 			sandbox.stub(message.guild!.channels.cache, "find").returns(message.channel as TextChannel);

--- a/test/event/handlers/LogMemberLeaveHandlerTest.ts
+++ b/test/event/handlers/LogMemberLeaveHandlerTest.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
-import { Collection, Constants, GuildMemberRoleManager, Role } from "discord.js";
+import { Collection, Constants, GuildMemberRoleManager, Role, TextChannel } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
-import { MEMBER_ROLE } from "../../../src/config.json";
+import { MEMBER_ROLE, LOG_CHANNEL_ID } from "../../../src/config.json";
 
 import EventHandler from "../../../src/abstracts/EventHandler";
 import LogMemberLeaveHandler from "../../../src/event/handlers/LogMemberLeaveHandler";
@@ -26,11 +26,13 @@ describe("LogMemberLeaveHandler", () => {
 			handler = new LogMemberLeaveHandler();
 		});
 
-		it("sends a message in logs channel when a member leaves", async () => {
+		it.only("sends a message in logs channel when a member leaves", async () => {
 			const message = CustomMocks.getMessage();
-			const messageMock = sandbox.stub(message.guild!.channels.cache, "find");
 
-			const guildMember = CustomMocks.getGuildMember({joined_at: 1610478967732});
+			sandbox.stub(message.guild!.channels.cache, "find").returns(message.channel as TextChannel);
+			const messageMock = sandbox.stub(message.channel, "send");
+
+			const guildMember = CustomMocks.getGuildMember({ joined_at: 1610478967732 });
 
 			const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
 				"id": MEMBER_ROLE.toString(),
@@ -46,6 +48,7 @@ describe("LogMemberLeaveHandler", () => {
 			await handler.handle(guildMember);
 
 			expect(messageMock.calledOnce).to.be.true;
+			expect(messageMock.firstCall.firstArg.embed.description).to.equal("User: my-username#1234 (010101010101010101)");
 		});
 
 		afterEach(() => {


### PR DESCRIPTION
Changed the message in the leave embed to be name#discriminator (id) instead of a mention.

Added raid detection on the leave event, now the bot will not send a message when the user is kicked because of a raid