### PR TITLE
DiscordMessageLinkHandler

### DIFF
--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -15,7 +15,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 			const index = match.index;
 
 			if (index !== undefined) {
-				let link = match[0];
+				let [link] = match;
 
 				if (message.content.charAt(index - 1) !== "<" || message.content.charAt(index + link.length) !== ">") {
 					link = link.replace(/app/, "").replace(/ptb\./, "");

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -8,21 +8,22 @@ class DiscordMessageLinkHandler extends EventHandler {
 	}
 
 	async handle(message: Message): Promise<void> {
-		const messageRegex = /https:\/\/(ptb\.)?discord(app)?\.com\/channels\//gm;
-		const linkIndex = message.content.search(messageRegex);
+		const messageRegex = /https:\/\/(?:ptb\.)?discord(?:app)?\.com\/channels\/\d+\/\d+\/\d+/gm;
+		const matches = [...message.content.matchAll(messageRegex)];
 
-		if (linkIndex === -1) return;
+		for (const match of matches) {
+			const index = match.index;
 
-		const wordIndex = message.content.slice(0, linkIndex).split(" ").length - 1;
-		const linkContent = message.content.split(" ")[wordIndex];
+			if (index !== undefined) {
+				let link = match[0];
 
-		if (linkContent.startsWith("<") && linkContent.endsWith(">")) return;
-
-		const link = message.content.replace(/app/, "").replace(/ptb\./, "").substring(linkIndex, linkIndex + 85);
-
-		const messagePreviewService = MessagePreviewService.getInstance();
-
-		await messagePreviewService.generatePreview(link, message);
+				if (message.content.charAt(index - 1) !== "<" || message.content.charAt(index + link.length) !== ">") {
+					link = link.replace(/app/, "").replace(/ptb\./, "");
+					const messagePreviewService = MessagePreviewService.getInstance();
+					await messagePreviewService.generatePreview(link, message);
+				}
+			}
+		}
 	}
 }
 

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -20,6 +20,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 				if (message.content.charAt(index - 1) !== "<" || message.content.charAt(index + link.length) !== ">") {
 					link = link.replace(/app/, "").replace(/ptb\./, "");
 					const messagePreviewService = MessagePreviewService.getInstance();
+
 					await messagePreviewService.generatePreview(link, message);
 				}
 			}

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -9,7 +9,7 @@ class DiscordMessageLinkHandler extends EventHandler {
 
 	async handle(message: Message): Promise<void> {
 		const messageRegex = /https:\/\/(?:ptb\.)?discord(?:app)?\.com\/channels\/\d+\/\d+\/\d+/gm;
-		const matches = [...message.content.matchAll(messageRegex)];
+		const matches = message.content.matchAll(messageRegex);
 
 		for (const match of matches) {
 			const index = match.index;

--- a/test/event/handlers/DiscordMessageLinkHandlerTest.ts
+++ b/test/event/handlers/DiscordMessageLinkHandlerTest.ts
@@ -25,6 +25,19 @@ describe("DiscordMessageLinkHandler", () => {
 			handler = new DiscordMessageLinkHandler();
 		});
 
+		it("sends a message in message channel when contains discord message link mid sentence", async () => {
+			const message = CustomMocks.getMessage();
+			const channel = CustomMocks.getTextChannel();
+			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
+
+			message.content = "aaaaaaaaa\nhttps://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982 aaaa";
+			message.channel = channel;
+
+			await handler.handle(message);
+
+			expect(generatePreviewMock.called).to.be.true;
+		});
+
 		it("sends a message in message channel when contains discord message link", async () => {
 			const message = CustomMocks.getMessage();
 			const channel = CustomMocks.getTextChannel();

--- a/test/event/handlers/DiscordMessageLinkHandlerTest.ts
+++ b/test/event/handlers/DiscordMessageLinkHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants } from "discord.js";
+import { Constants, Message, TextChannel } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -19,15 +19,17 @@ describe("DiscordMessageLinkHandler", () => {
 	describe("handle()", () => {
 		let sandbox: SinonSandbox;
 		let handler: EventHandler;
+		let message: Message;
+		let channel: TextChannel;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			handler = new DiscordMessageLinkHandler();
+			message = CustomMocks.getMessage();
+			channel = CustomMocks.getTextChannel();
 		});
 
 		it("sends a message in message channel when contains discord message link mid sentence", async () => {
-			const message = CustomMocks.getMessage();
-			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "aaaaaaaaa\nhttps://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982 aaaa";
@@ -39,8 +41,6 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("sends a message in message channel when contains discord message link", async () => {
-			const message = CustomMocks.getMessage();
-			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982";
@@ -52,8 +52,6 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("sends a single message in message channel when contains multiple discord message links however one is escaped", async () => {
-			const message = CustomMocks.getMessage();
-			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982 <https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982>";
@@ -65,8 +63,6 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("sends multiple messages in message channel when contains multiple discord message link", async () => {
-			const message = CustomMocks.getMessage();
-			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982 https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982";
@@ -78,8 +74,6 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("does not send a message if the message starts with < and ends with >", async () => {
-			const message = CustomMocks.getMessage();
-			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "<https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982>";
@@ -91,8 +85,6 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("does not send a message if the url was escaped mid sentence", async () => {
-			const message = CustomMocks.getMessage();
-			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "placeholderText <https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982> placeholderText";

--- a/test/event/handlers/DiscordMessageLinkHandlerTest.ts
+++ b/test/event/handlers/DiscordMessageLinkHandlerTest.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { Constants } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
-import { BaseMocks } from "@lambocreeper/mock-discord.js";
+import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
 import EventHandler from "../../../src/abstracts/EventHandler";
 import MessagePreviewService from "../../../src/services/MessagePreviewService";
@@ -26,8 +26,8 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("sends a message in message channel when contains discord message link", async () => {
-			const message = BaseMocks.getMessage();
-			const channel = BaseMocks.getTextChannel();
+			const message = CustomMocks.getMessage();
+			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982";
@@ -38,9 +38,35 @@ describe("DiscordMessageLinkHandler", () => {
 			expect(generatePreviewMock.called).to.be.true;
 		});
 
+		it("sends a single message in message channel when contains multiple discord message links however one is escaped", async () => {
+			const message = CustomMocks.getMessage();
+			const channel = CustomMocks.getTextChannel();
+			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
+
+			message.content = "https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982 <https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982>";
+			message.channel = channel;
+
+			await handler.handle(message);
+
+			expect(generatePreviewMock.calledOnce).to.be.true;
+		});
+
+		it("sends multiple messages in message channel when contains multiple discord message link", async () => {
+			const message = CustomMocks.getMessage();
+			const channel = CustomMocks.getTextChannel();
+			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
+
+			message.content = "https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982 https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982";
+			message.channel = channel;
+
+			await handler.handle(message);
+
+			expect(generatePreviewMock.calledTwice).to.be.true;
+		});
+
 		it("does not send a message if the message starts with < and ends with >", async () => {
-			const message = BaseMocks.getMessage();
-			const channel = BaseMocks.getTextChannel();
+			const message = CustomMocks.getMessage();
+			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "<https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982>";
@@ -52,8 +78,8 @@ describe("DiscordMessageLinkHandler", () => {
 		});
 
 		it("does not send a message if the url was escaped mid sentence", async () => {
-			const message = BaseMocks.getMessage();
-			const channel = BaseMocks.getTextChannel();
+			const message = CustomMocks.getMessage();
+			const channel = CustomMocks.getTextChannel();
 			const generatePreviewMock = sandbox.stub(MessagePreviewService.prototype, "generatePreview");
 
 			message.content = "placeholderText <https://ptb.discordapp.com/channels/240880736851329024/518817917438001152/732711501345062982> placeholderText";
@@ -63,6 +89,7 @@ describe("DiscordMessageLinkHandler", () => {
 
 			expect(generatePreviewMock.called).to.be.false;
 		});
+
 		afterEach(() => {
 			sandbox.restore();
 		});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "outDir": "./build",
     "rootDir": "./src",
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "lib": ["es2020.string"]
   },
   "exclude": ["./test"]
 }


### PR DESCRIPTION
# DiscordMessageLinkHandler
## Summary
This PR changes `DiscordMessageLinkHandler` to cater for an issue brought up where it was not correctly handling new lines, it also fixes an issue where the previous handler only ever worked in the context of a single message link within a given message.

### Testing
##### Single message with other text
<img width="801" alt="Screenshot 2021-03-02 at 19 52 15" src="https://user-images.githubusercontent.com/20248039/109706732-36839700-7b91-11eb-8638-3df043be02a6.png">

##### Multiple links, still caters for escaped links too
<img width="781" alt="Screenshot 2021-03-02 at 19 52 24" src="https://user-images.githubusercontent.com/20248039/109706744-3aafb480-7b91-11eb-969a-153c714541d7.png">

##### Multiple links
<img width="822" alt="Screenshot 2021-03-02 at 19 52 34" src="https://user-images.githubusercontent.com/20248039/109706801-4f8c4800-7b91-11eb-9c94-545575cb5598.png">

## Note
This PR had to change the tsconfig to allow for `matchAll` along with an issue regarding iterating.