### PR TITLE
Using .get for IDs instead of .find

### DIFF
--- a/src/abstracts/LogMessageDeleteHandler.ts
+++ b/src/abstracts/LogMessageDeleteHandler.ts
@@ -12,7 +12,7 @@ abstract class LogMessageDeleteHandler extends EventHandler {
 			embed.addField("Message", message.content);
 			embed.setColor(EMBED_COLOURS.DEFAULT);
 
-			const logsChannel = message.guild?.channels.cache.find(channel => channel.id === LOG_CHANNEL_ID) as TextChannel;
+			const logsChannel = message.guild?.channels.cache.get(LOG_CHANNEL_ID) as TextChannel;
 
 			await logsChannel?.send({ embed });
 		}


### PR DESCRIPTION
<Collection>.find() (similar to <Array>.find(<callback>) )iterates through the collection to get the channel, whereas <Collection>.get("ID") is <Map>.get(<Key>)
it's more eficient