### PR TITLE
InviteCycler concept

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -94,5 +94,10 @@
             "description": "Keep it appropriate, some people use this at school or at work."
         }
     ],
-    "MAX_INVITE_USAGE": 1
+    "INVITE": {
+        "MAX_USAGE": 1,
+        "CHANNEL_ID": "826154294876962826",
+        "MESSAGE": "826160859222638633"
+    }
+
 }

--- a/src/config.json
+++ b/src/config.json
@@ -93,5 +93,6 @@
             "triggers": ["9", "sfw", "clean", "appropriate"],
             "description": "Keep it appropriate, some people use this at school or at work."
         }
-    ]
+    ],
+    "MAX_INVITE_USAGE": 1
 }

--- a/src/event/handlers/InviteCycleHandler.ts
+++ b/src/event/handlers/InviteCycleHandler.ts
@@ -1,0 +1,35 @@
+import {Constants, GuildChannel, Invite, TextChannel} from "discord.js";
+import { MAX_INVITE_USAGE} from "../../config.json";
+
+import EventHandler from "../../abstracts/EventHandler";
+
+class InviteCycleHandler extends EventHandler {
+	constructor() {
+		super(Constants.Events.INVITE_DELETE);
+	}
+
+	async handle(invite: Invite): Promise<void> {
+		const guildChannel = await invite.channel as GuildChannel;
+
+		const createdInvite = await guildChannel.createInvite({
+			maxUses: MAX_INVITE_USAGE,
+			maxAge: 0,
+			unique: true
+		});
+
+		const inviteChannel = await invite.guild?.channels.cache.find(channel => channel.id === createdInvite.channel.id) as TextChannel;
+
+		const messages = await inviteChannel.messages.fetch();
+
+		const firstMessage = messages.first();
+
+		if (firstMessage?.author.id === createdInvite.inviter?.id) {
+		firstMessage?.edit(createdInvite.toString());
+		return;
+		}
+
+		await inviteChannel.send(createdInvite.toString());
+	}
+}
+
+export default InviteCycleHandler;

--- a/src/event/handlers/InviteCycleHandler.ts
+++ b/src/event/handlers/InviteCycleHandler.ts
@@ -1,5 +1,5 @@
-import {Constants, GuildChannel, Invite, TextChannel} from "discord.js";
-import { MAX_INVITE_USAGE} from "../../config.json";
+import {Constants, Invite, TextChannel} from "discord.js";
+import { INVITE } from "../../config.json";
 
 import EventHandler from "../../abstracts/EventHandler";
 
@@ -9,26 +9,17 @@ class InviteCycleHandler extends EventHandler {
 	}
 
 	async handle(invite: Invite): Promise<void> {
-		const guildChannel = await invite.channel as GuildChannel;
+		const inviteChannel = invite.guild?.channels.cache.get(INVITE.CHANNEL_ID) as TextChannel;
 
-		const createdInvite = await guildChannel.createInvite({
-			maxUses: MAX_INVITE_USAGE,
+		const createdInvite = await inviteChannel.createInvite({
+			maxUses: INVITE.MAX_USAGE,
 			maxAge: 0,
 			unique: true
 		});
 
-		const inviteChannel = await invite.guild?.channels.cache.find(channel => channel.id === createdInvite.channel.id) as TextChannel;
+		const message = await inviteChannel.messages.fetch(INVITE.MESSAGE);
 
-		const messages = await inviteChannel.messages.fetch();
-
-		const firstMessage = messages.first();
-
-		if (firstMessage?.author.id === createdInvite.inviter?.id) {
-		firstMessage?.edit(createdInvite.toString());
-		return;
-		}
-
-		await inviteChannel.send(createdInvite.toString());
+		await message.edit(createdInvite.toString());
 	}
 }
 


### PR DESCRIPTION
So I made another prevention against those raiders. This handler basically uses the maxUse invite feature to create a new invite when the old one expires. This would change a public invite out when its expired, meaning that you have to use a new invite link, this will stop the raiders from joining in masses.

This needs some setup:
- Disallow **anyone** from making invites.
- Delete all existing invites (the bot should be off if you do this)

Then you can startup the bot,
- Make an invite to right channel yourself (most likely #rules-and-info in our case)
- Delete that invite

Now the bot wil create an invite itself and set the invite designation to that channel. it will also send a message in that channel containing the invite url (that message will also be edited with the new invite when it gets created)

This still a concept and probably needs some work, even if this concept gets accepted, I still need to write tests.