### PR TITLE
Project command updated and ProjectService Added

### DIFF
--- a/src/commands/ProjectCommand.ts
+++ b/src/commands/ProjectCommand.ts
@@ -6,8 +6,6 @@ import projects from "../src-assets/projects.json";
 import StringUtils from "../utils/StringUtils";
 
 export default class ProjectCommand extends Command {
-	private readonly defaultSearchTags = ["easy", "medium", "hard"];
-
 	constructor() {
 		super(
 			"project",
@@ -18,12 +16,13 @@ export default class ProjectCommand extends Command {
 		);
 	}
 
+	private readonly defaultSearchTags = ["easy", "medium", "hard"];
 	readonly provideProjects: () => Array<Project> = () => projects;
 
 	async run(message: Message, args: string[]): Promise<void> {
 		const embed = new MessageEmbed();
 
-		const query = args.map((arg: string) => arg.toLowerCase()).filter((arg: string) => arg.trim().length > 0);
+		const query = args.map((arg: string) => arg.replace("#", "").toLowerCase()).filter((arg: string) => arg.trim().length > 0);
 
 		if (args.length === 0) {
 			embed.setTitle("Error");

--- a/src/commands/ProjectCommand.ts
+++ b/src/commands/ProjectCommand.ts
@@ -1,9 +1,8 @@
 import Command from "../abstracts/Command";
 import { Message, MessageEmbed } from "discord.js";
 import { EMBED_COLOURS } from "../config.json";
-import Project from "../interfaces/Project";
-import projects from "../src-assets/projects.json";
 import StringUtils from "../utils/StringUtils";
+import ProjectService from "../services/ProjectService";
 
 export default class ProjectCommand extends Command {
 	constructor() {
@@ -16,48 +15,30 @@ export default class ProjectCommand extends Command {
 		);
 	}
 
-	private readonly defaultSearchTags = ["easy", "medium", "hard"];
-	readonly provideProjects: () => Array<Project> = () => projects;
-
 	async run(message: Message, args: string[]): Promise<void> {
 		const embed = new MessageEmbed();
 
-		const query = args.map((arg: string) => arg.replace("#", "").toLowerCase()).filter((arg: string) => arg.trim().length > 0);
+		try {
+			const projectService = ProjectService.getInstance();
+			const tags = projectService.formatTags(args);
+			const projectInformation = projectService.getProjectByTags(tags);
 
-		if (args.length === 0) {
+			if (projectInformation === null) throw "Error";
+
+			const difficulty = projectService.getDifficulty(projectInformation);
+
+			embed.setTitle(`Project: ${projectInformation.title}`);
+			embed.setDescription(projectInformation.description);
+			embed.addField("Difficulty", StringUtils.capitalise(difficulty), true);
+			embed.addField("Tags", projectInformation.tags.map(tag => `#${tag}`).join(", "), true);
+			console.log("Breakpoint 3");
+			embed.setColor(EMBED_COLOURS.DEFAULT);
+		} catch {
 			embed.setTitle("Error");
-			embed.setDescription("You must provide a search query/tag.");
-			embed.addField("Correct Usage", "?projects <query>");
 			embed.setColor(EMBED_COLOURS.ERROR);
-		} else {
-			const displayProject = this.provideProjects()
-				.filter(this.removeTooLongDescriptions)
-				.filter(project => this.filterTags(project, query))
-				.sort(() => 0.5 - Math.random()).pop();
-
-			if (displayProject) {
-				const difficulty = this.retrieveFirstFoundTag(displayProject, this.defaultSearchTags);
-
-				embed.setTitle(`Project: ${displayProject.title}`);
-				embed.setDescription(displayProject.description);
-				if (difficulty) embed.addField("Difficulty", StringUtils.capitalise(difficulty), true);
-				embed.addField("Tags", displayProject.tags.map(tag => `#${tag}`).join(", "), true);
-				embed.setColor(EMBED_COLOURS.DEFAULT);
-			} else {
-				embed.setTitle("Error");
-				embed.setColor(EMBED_COLOURS.ERROR);
-				embed.setDescription("Could not find a project result for the given query.");
-			}
+			embed.setDescription("Could not find a project result for the given query.");
 		}
 
 		await message.channel.send(embed);
 	}
-
-	private readonly removeTooLongDescriptions: (project: Project) => boolean = ({description}) => description.length <= 2048;
-
-	private readonly filterTags: (project: Project, requestedTags: Array<string>) => boolean =
-		({tags}, requestedTags: Array<string>) => requestedTags.every(tag => tags.includes(tag));
-
-	private readonly retrieveFirstFoundTag: (project: Project, tagsToRetrieve: Array<string>) => string | undefined =
-		({tags}, tagsToRetrieve: Array<string>) => tagsToRetrieve.filter(tag => tags.map((tag: string) => tag.toLowerCase()).includes(tag)).pop();
 }

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -18,11 +18,6 @@ class ProjectService {
 		return this.instance;
 	}
 
-	/*
-	Formats tags to be used by other methods
-	@param tags - Takes in an array of unformatted tags
-	@returns string[] - List of formatted tags
-	 */
 	public formatTags(args: string[]): string[] {
 		const formattedTags = args.map((arg: string) => arg.replace("#", "").toLowerCase());
 

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -1,0 +1,47 @@
+import projectsList from "../src-assets/projects.json";
+import Project from "../interfaces/Project";
+
+class ProjectService {
+	private static instance: ProjectService;
+
+	/* eslint-disable */
+	private constructor() {
+	}
+
+	/* eslint-enable */
+
+	static getInstance(): ProjectService {
+		if (!this.instance) {
+			this.instance = new ProjectService();
+		}
+
+		return this.instance;
+	}
+
+	/*
+	Formats tags to be used by other methods
+	@param tags - Takes in an array of unformatted tags
+	@returns string[] - List of formatted tags
+	 */
+	public formatTags(args: string[]): string[] {
+		const formattedTags = args.map((arg: string) => arg.replace("#", "").toLowerCase());
+
+		return formattedTags.filter((arg: string) => arg.trim().length > 0);
+	}
+
+	public getProjectByTags(tags: string[]): Project | null {
+		if (tags.length === 0) return projectsList[~~(projectsList.length * Math.random())];
+
+		const filterProjects = projectsList.filter(project => tags.every(item => project.tags.includes(item)));
+
+		return filterProjects[~~(filterProjects.length * Math.random())];
+	}
+
+	public getDifficulty(project: Project) {
+		const difficultyLevels = ["easy", "medium", "hard"];
+
+		return difficultyLevels.filter(element => project.tags.includes(element))[0];
+	}
+}
+
+export default ProjectService;

--- a/test/commands/ProjectCommandTest.ts
+++ b/test/commands/ProjectCommandTest.ts
@@ -5,66 +5,45 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import Command from "../../src/abstracts/Command";
 import { EMBED_COLOURS } from "../../src/config.json";
 import ProjectCommand from "../../src/commands/ProjectCommand";
+import ProjectService from "../../src/services/ProjectService";
 
 describe("ProjectCommand", () => {
 	describe("constructor", () => {
 		const command = new ProjectCommand();
 
-		it("Should have the name 'Project'", () => {
+		it("creates a command called project", () => {
 			expect(command.getName()).to.equal("project");
 		});
 
-		it("Should set the correct description", () => {
+		it("creates a command with correct description", () => {
 			expect(command.getDescription()).to.equal("Returns a random project idea based on given parameters.");
+		});
+
+		it("creates a command with correct aliases", () => {
+			expect(command.getAliases().includes("projects")).to.be.true;
 		});
 	});
 
 	describe("run()", () => {
 		const command: Command = new ProjectCommand();
-		const mockProjects: Array<any> = [
-			{
-				title: Math.random().toString(36),
-				tags: ["1", "hard"],
-				description: Math.random().toString(36)
-			},
-			{
-				title: Math.random().toString(36),
-				tags: ["2", "3", "default"],
-				description: Math.random().toString(36)
-			},
-			{
-				title: Math.random().toString(36),
-				tags: ["4", "medium"],
-				description: Math.random().toString(36)
-			},
-			{
-				title: Math.random().toString(36),
-				tags: ["5", "easy"],
-				description: Math.random().toString(36)
-			},
-			{
-				title: Math.random().toString(36),
-				tags: ["6"],
-				description: [...Array(100)].map(() => Math.random().toString(36)).join(Math.random().toString(36))
-			}
-		];
 		let sandbox: SinonSandbox;
 		let message: Message;
+		let projectService: ProjectService;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			message = BaseMocks.getMessage();
-			sandbox.stub(command as ProjectCommand, "provideProjects").callsFake(() => mockProjects);
+			projectService = ProjectService.getInstance();
 		});
 
 		afterEach(() => {
 			sandbox.restore();
 		});
 
-		it("returns an embed to request the user to search with less args if no result is found for given args", async () => {
+		it("returns an embed stating that no project was found with the given query", async () => {
 			const messageMock = sandbox.stub(message.channel, "send");
 
-			await command.run(message, [Math.random().toString(36)]);
+			await command.run(message, ["#sinontest-stubbing-project-command-4e2xnwj54z"]);
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = messageMock.getCall(0).firstArg;
@@ -75,55 +54,28 @@ describe("ProjectCommand", () => {
 			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
 		});
 
-		it("should assign the correct colors for difficulty grade if difficulty grade is specified", async () => {
+		it("should return an embed with project information", async () => {
 			const messageMock = sandbox.stub(message.channel, "send");
 
-			await command.run(message, ["default"]);
+			sandbox.stub(projectService, "getProjectByTags").returns({
+				title: "Mock Project",
+				description: "Once upon a time",
+				tags: ["easy", "vue", "front-end"]
+			});
+
 			await command.run(message, ["easy"]);
-			await command.run(message, ["medium"]);
-			await command.run(message, ["hard"]);
 
 			// @ts-ignore - firstArg does not live on getCall()
-			const firstCall = messageMock.getCall(0).firstArg;
-			// @ts-ignore - firstArg does not live on getCall()
-			const secondCall = messageMock.getCall(1).firstArg;
-			// @ts-ignore - firstArg does not live on getCall()
-			const thirdCall = messageMock.getCall(2).firstArg;
-			// @ts-ignore - firstArg does not live on getCall()
-			const lastCall = messageMock.getCall(3).firstArg;
-
-			expect(firstCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-			expect(secondCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-			expect(thirdCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-			expect(lastCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-		});
-
-		it("should filter out too long descriptions out of the resultset", async () => {
-			const messageMock = sandbox.stub(message.channel, "send");
-
-			await command.run(message, ["6"]);
-
-			// @ts-ignore - firstArg does not live on getCall()
-			const firstCall = messageMock.getCall(0).firstArg;
+			const embed = messageMock.getCall(0).firstArg;
 
 			expect(messageMock.calledOnce).to.be.true;
-			expect(firstCall.title).to.equal("Error");
-			expect(firstCall.description).to.equal("Could not find a project result for the given query.");
-			expect(firstCall.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
-		});
-
-		it("should return instructions on how to use the command if no args are provided", async () => {
-			const messageMock = sandbox.stub(message.channel, "send");
-
-			await command.run(message, []);
-
-			// @ts-ignore - firstArg does not live on getCall()
-			const firstCall = messageMock.getCall(0).firstArg;
-
-			expect(messageMock.calledOnce).to.be.true;
-			expect(firstCall.title).to.equal("Error");
-			expect(firstCall.description).to.equal("You must provide a search query/tag.");
-			expect(firstCall.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.title).to.equal("Project: Mock Project");
+			expect(embed.description).to.equal("Once upon a time");
+			expect(embed.fields[0].name).to.equal("Difficulty");
+			expect(embed.fields[0].value).to.equal("Easy");
+			expect(embed.fields[1].name).to.equal("Tags");
+			expect(embed.fields[1].value).to.equal("#easy, #vue, #front-end");
+			expect(embed.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
 		});
 	});
 });

--- a/test/services/ProjectServiceTest.ts
+++ b/test/services/ProjectServiceTest.ts
@@ -1,0 +1,79 @@
+import {createSandbox, SinonSandbox} from "sinon";
+import {expect} from "chai";
+import ProjectService from "../../src/services/ProjectService";
+import Project from "../../src/interfaces/Project";
+
+describe("ProjectService", () => {
+	describe("::getInstance()", () => {
+		it("returns an instance of ProjectService", () => {
+			const service = ProjectService.getInstance();
+
+			expect(service).to.be.instanceOf(ProjectService);
+		});
+	});
+
+	describe("formatTags()", () => {
+		let sandbox: SinonSandbox;
+		let projectService: ProjectService;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+			projectService = ProjectService.getInstance();
+		});
+
+		it("formats all arguments to be usable as tags", async () => {
+			const unformattedTags = ["#REACT", "FRONT-END", "#vue"];
+			const tags = await projectService.formatTags(unformattedTags);
+
+			expect(tags).to.deep.equal(["react", "front-end", "vue"]);
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+	});
+
+	describe("getProjectByTags()", () => {
+		let sandbox: SinonSandbox;
+		// Let projectService: ProjectService;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+		//	ProjectService = ProjectService.getInstance();
+		});
+
+		it("returns a single project", async () => {
+			//
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+	});
+
+	describe("getDifficulty()", () => {
+		let sandbox: SinonSandbox;
+		let projectService: ProjectService;
+
+		beforeEach(() => {
+			sandbox = createSandbox();
+			projectService = ProjectService.getInstance();
+		});
+
+		it("returns the difficulty by recognizing the tag", async () => {
+			const mockProject: Project = {
+				title: "Mocking",
+				description: "Hello World",
+				tags: ["easy", "javascript", "react"]
+			};
+
+			const difficulty = projectService.getDifficulty(mockProject);
+
+			expect(difficulty).to.equal("easy");
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+	});
+});


### PR DESCRIPTION
Hey, 

Made some changes to the Project Command and added a ProjectService

First commit:

`?project`  without any query now returns any random project.
`?project #react`, tags with # infront now also work as query.

Second Commit

Extracted all Project code to a ProjectService so the project command only has to take care of making it look nice and so it fits better with the rest of the codebase.

ProjectService has 3 methods:
- formatTags
- getProjectByTags
- getDifficulty 


Todo: 
- Figure out how to mock the projects json file so I can write more tests for the ProjectService
