### PR TITLE
Fix ghost pinging bots being detected

### DIFF
--- a/src/event/handlers/GhostPingHandler.ts
+++ b/src/event/handlers/GhostPingHandler.ts
@@ -13,7 +13,7 @@ class GhostPingHandler extends EventHandler {
 			if (!message.author?.bot) {
 				const usersMentioned = message.mentions.users;
 
-				if (usersMentioned.first()?.id === message.author.id && usersMentioned.size === 1) return;
+				if (usersMentioned.every(user => user.id === message.author.id || user.bot)) return;
 
 				const embed = new MessageEmbed();
 


### PR DESCRIPTION
Bots don't care if they're ghost pinged, so it shouldn't be detected.

Resolves #196 

### Overview
- Make the ghost ping not be detected when author only mentions himself and/or bots, and when author replies to a bot.
- Add test cases which check the scenarios when author pings himself and bot, pings just bots, replies to bot.
