### PR TITLE
Solves the raid handler attempting to kick the same user several time…

### DIFF
--- a/src/event/handlers/RaidDetectionHandler.ts
+++ b/src/event/handlers/RaidDetectionHandler.ts
@@ -17,12 +17,11 @@ class RaidDetectionHandler extends EventHandler {
 		this.joinQueue.push(member);
 		if (this.joinQueue.length >= getConfigValue<GenericObject<number>>("RAID_SETTINGS").MAX_QUEUE_SIZE && !this.kickFlag) {
 			this.kickFlag = true;
-			await this.kickArray(member);
-			this.kickFlag = false;
+			this.kickArray(member).then(() => this.kickFlag = false);
 		}
 
 		setTimeout(() => {
-			if (this.joinQueue.includes(member)) {
+			if (this.joinQueue.includes(member) && !this.kickFlag) {
 				this.joinQueue.splice(this.joinQueue.indexOf(member), 1);
 			}
 		}, timeToWait);

--- a/src/event/handlers/RaidDetectionHandler.ts
+++ b/src/event/handlers/RaidDetectionHandler.ts
@@ -17,9 +17,10 @@ class RaidDetectionHandler extends EventHandler {
 		this.joinQueue.push(member);
 		if (this.joinQueue.length >= getConfigValue<GenericObject<number>>("RAID_SETTINGS").MAX_QUEUE_SIZE && !this.kickFlag) {
 			this.kickFlag = true;
-			this.kickArray(member).then(() => this.kickFlag = false);
+			await this.kickArray(member);
+			this.kickFlag = false;
 		}
-
+		console.log(`Length: ${this.joinQueue.length} Cap ${getConfigValue<GenericObject<number>>("RAID_SETTINGS").MAX_QUEUE_SIZE}`);
 		setTimeout(() => {
 			if (this.joinQueue.includes(member) && !this.kickFlag) {
 				this.joinQueue.splice(this.joinQueue.indexOf(member), 1);

--- a/src/event/handlers/RaidDetectionHandler.ts
+++ b/src/event/handlers/RaidDetectionHandler.ts
@@ -5,6 +5,7 @@ import GenericObject from "../../interfaces/GenericObject";
 
 class RaidDetectionHandler extends EventHandler {
 	private joinQueue: GuildMember[] = [];
+	private kickFlag = false;
 
 	constructor() {
 		super(Constants.Events.GUILD_MEMBER_ADD);
@@ -12,37 +13,12 @@ class RaidDetectionHandler extends EventHandler {
 
 	handle = async (member: GuildMember): Promise<void> => {
 		const timeToWait = 1000 * getConfigValue<GenericObject<number>>("RAID_SETTINGS").TIME_TILL_REMOVAL;
-		const modChannel = member.guild?.channels.cache.find(channel => channel.id === getConfigValue<string>("LOG_CHANNEL_ID")) as TextChannel;
-		const generalChannel = member.guild?.channels.cache.find(channel => channel.id === getConfigValue<string>("GENERAL_CHANNEL_ID")) as TextChannel;
 
 		this.joinQueue.push(member);
-
-		if (this.joinQueue.length >= getConfigValue<GenericObject<number>>("RAID_SETTINGS").MAX_QUEUE_SIZE) {
-			try {
-				await Promise.all(this.joinQueue.map(async member => {
-					await member.kick("Detected as part of a raid.");
-					await modChannel.send(`@<${getConfigValue<string>("MOD_ROLE")}> **RAID DETECTION** Kicked user ${member.displayName} (${member.id}).`);
-				}));
-
-				this.joinQueue = [];
-
-				const embed = new MessageEmbed();
-
-				embed.setTitle(":warning: Raid Detected");
-				embed.setDescription(`**We have detected a raid is currently going on and are solving the issue.**
-					Please refrain from notifying the moderators or spamming this channel.
-					Thank you for your cooperation and we apologise for any inconvenience.`);
-				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").WARNING);
-				embed.setTimestamp();
-
-				await generalChannel.send({embeds: [embed]});
-			} catch (error) {
-				console.error(error);
-
-				if (error instanceof Error) {
-					await modChannel.send(`Failed to kick users or empty queue: \n\`${error.message}\``);
-				}
-			}
+		if (this.joinQueue.length >= getConfigValue<GenericObject<number>>("RAID_SETTINGS").MAX_QUEUE_SIZE && !this.kickFlag) {
+			this.kickFlag = true;
+			await this.kickArray(member);
+			this.kickFlag = false;
 		}
 
 		setTimeout(() => {
@@ -50,6 +26,36 @@ class RaidDetectionHandler extends EventHandler {
 				this.joinQueue.splice(this.joinQueue.indexOf(member), 1);
 			}
 		}, timeToWait);
+	}
+
+	private async kickArray(member: GuildMember) {
+		const modChannel = member.guild?.channels.cache.find(channel => channel.id === getConfigValue<string>("LOG_CHANNEL_ID")) as TextChannel;
+		const generalChannel = member.guild?.channels.cache.find(channel => channel.id === getConfigValue<string>("GENERAL_CHANNEL_ID")) as TextChannel;
+
+		try {
+			while (this.joinQueue.length > 0) {
+				const member = this.joinQueue.shift()!!;
+
+				await member.kick("Detected as part of a raid.");
+				await modChannel.send(`**RAID DETECTION** Kicked user ${member.displayName} (${member.id}).`);
+			}
+
+			const embed = new MessageEmbed();
+
+			embed.setTitle(":warning: Raid Detected");
+			embed.setDescription(`**We have detected a raid is currently going on and are solving the issue.**
+							Please refrain from notifying the moderators or spamming this channel.
+							Thank you for your cooperation and we apologise for any inconvenience.`);
+			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").WARNING);
+			embed.setTimestamp();
+			await generalChannel.send({embeds: [embed]});
+		} catch (error: any) {
+			console.error(error);
+
+			if (error instanceof Error) {
+				await modChannel.send(`Failed to kick users or empty queue: \n\`${error.message}\``);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
…s depending on the ratelimit

Resolves #190

### Overview
Please bullet point the changes you have made below:
- Lowered the amount of Raid Detection messages to 1 in general
- Prevents the handler's setTimeout from attempting to kick the same user multiple times