### PR TITLE
Add error handling for message preview handler

### DIFF
--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -23,12 +23,12 @@ class MessagePreviewService {
 		if (this.verifyGuild(callingMessage, msgArray[0])) {
 			if (callingMessage.guild?.available) {
 				const channel = callingMessage.guild.channels.cache.get(<Snowflake>msgArray[1]) as TextChannel;
-				let messageToPreview = null;
+				let messageToPreview;
 
 				try {
 					messageToPreview = await channel?.messages.fetch(<Snowflake>msgArray[2]);
 				} catch (e) {
-					// Silence error on wrong channel ID
+					// Silence error on wrong message ID
 				}
 
 				if (messageToPreview && !messageToPreview.author?.bot) {

--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -23,9 +23,15 @@ class MessagePreviewService {
 		if (this.verifyGuild(callingMessage, msgArray[0])) {
 			if (callingMessage.guild?.available) {
 				const channel = callingMessage.guild.channels.cache.get(<Snowflake>msgArray[1]) as TextChannel;
-				const messageToPreview = await channel.messages.fetch(<Snowflake>msgArray[2]);
+				let messageToPreview = null;
 
-				if (!messageToPreview.author?.bot) {
+				try {
+					messageToPreview = await channel?.messages.fetch(<Snowflake>msgArray[2]);
+				} catch (e) {
+					// Silence error on wrong channel ID
+				}
+
+				if (messageToPreview && !messageToPreview.author?.bot) {
 					const embed = new MessageEmbed();
 					const parsedContent = this.escapeHyperlinks(messageToPreview.content);
 

--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -23,13 +23,7 @@ class MessagePreviewService {
 		if (this.verifyGuild(callingMessage, msgArray[0])) {
 			if (callingMessage.guild?.available) {
 				const channel = callingMessage.guild.channels.cache.get(<Snowflake>msgArray[1]) as TextChannel;
-				let messageToPreview;
-
-				try {
-					messageToPreview = await channel?.messages.fetch(<Snowflake>msgArray[2]);
-				} catch (e) {
-					// Silence error on wrong message ID
-				}
+				const messageToPreview = await channel?.messages.fetch(<Snowflake>msgArray[2]).catch(console.warn);
 
 				if (messageToPreview && !messageToPreview.author?.bot) {
 					const embed = new MessageEmbed();

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -22,7 +22,7 @@ describe("MessagePreviewService", () => {
 		let channel: TextChannel;
 		let getChannelMock: SinonStub;
 		let sendMessageMock: SinonStub;
-		let channelFetchMock: SinonStub;
+		let fetchMessageMock: SinonStub;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
@@ -47,7 +47,7 @@ describe("MessagePreviewService", () => {
 			getChannelMock = sandbox.stub(callingMessage.guild.channels.cache, "get").returns(channel);
 			sendMessageMock = sandbox.stub(callingMessage.channel, "send");
 
-			channelFetchMock = sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
+			fetchMessageMock = sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
 			sandbox.stub(callingMessage.member, "displayColor").get(() => "#FFFFFF");
 		});
 
@@ -88,9 +88,9 @@ describe("MessagePreviewService", () => {
 			expect(sendMessageMock.called).to.be.false;
 		});
 
-		it.only("doesn't send preview message if the message ID is wrong", async () => {
-			channelFetchMock.restore();
-			channelFetchMock = sandbox.stub(channel.messages, "fetch").throwsException();
+		it("doesn't send preview message if the message ID is wrong", async () => {
+			fetchMessageMock.restore();
+			fetchMessageMock = sandbox.stub(channel.messages, "fetch").throwsException();
 
 			await messagePreview.generatePreview(link, callingMessage);
 

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -90,7 +90,7 @@ describe("MessagePreviewService", () => {
 
 		it("doesn't send preview message if the message ID is wrong", async () => {
 			fetchMessageMock.restore();
-			fetchMessageMock = sandbox.stub(channel.messages, "fetch").throwsException();
+			fetchMessageMock = sandbox.stub(channel.messages, "fetch").returns(Promise.reject());
 
 			await messagePreview.generatePreview(link, callingMessage);
 

--- a/test/services/MessagePreviewServiceTest.ts
+++ b/test/services/MessagePreviewServiceTest.ts
@@ -22,6 +22,7 @@ describe("MessagePreviewService", () => {
 		let channel: TextChannel;
 		let getChannelMock: SinonStub;
 		let sendMessageMock: SinonStub;
+		let channelFetchMock: SinonStub;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
@@ -46,7 +47,7 @@ describe("MessagePreviewService", () => {
 			getChannelMock = sandbox.stub(callingMessage.guild.channels.cache, "get").returns(channel);
 			sendMessageMock = sandbox.stub(callingMessage.channel, "send");
 
-			sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
+			channelFetchMock = sandbox.stub(channel.messages, "fetch").resolves(callingMessage);
 			sandbox.stub(callingMessage.member, "displayColor").get(() => "#FFFFFF");
 		});
 
@@ -72,6 +73,26 @@ describe("MessagePreviewService", () => {
 
 		it("doesn't send preview message if it is a bot message", async () => {
 			callingMessage.author.bot = true;
+
+			await messagePreview.generatePreview(link, callingMessage);
+
+			expect(sendMessageMock.called).to.be.false;
+		});
+
+		it("doesn't send preview message if the channel ID is wrong", async () => {
+			getChannelMock.restore();
+			getChannelMock = sandbox.stub(callingMessage.guild.channels.cache, "get").returns(undefined);
+
+			await messagePreview.generatePreview(link, callingMessage);
+
+			expect(sendMessageMock.called).to.be.false;
+		});
+
+		it.only("doesn't send preview message if the message ID is wrong", async () => {
+			channelFetchMock.restore();
+			channelFetchMock = sandbox.stub(channel.messages, "fetch").throwsException();
+
+			await messagePreview.generatePreview(link, callingMessage);
 
 			expect(sendMessageMock.called).to.be.false;
 		});


### PR DESCRIPTION
Resolves #227 

### Overview
Please bullet point the changes you have made below:
- Adds error handling surrounding bad channel / message IDs
- Adds related tests
- Fixes an issue where the preview generate method wasn't being called in one of the tests
