### PR TITLE
Update intents to not listen to presence updates

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,7 @@ class App {
 		this.client = new Client({
 			botId: getConfigValue<string>("BOT_ID"),
 			botGuilds: [getConfigValue<string>("GUILD_ID")],
-			intents: DiscordUtils.getAllIntents()
+			intents: DiscordUtils.getAllIntentsApartFromPresence()
 		});
 	}
 

--- a/src/utils/DiscordUtils.ts
+++ b/src/utils/DiscordUtils.ts
@@ -32,6 +32,20 @@ class DiscordUtils {
 		// https://github.com/discordjs/discord.js/blob/51551f544b80d7d27ab0b315da01dfc560b2c115/src/util/Intents.js#L75
 		return Object.values(Intents.FLAGS).reduce((acc, p) => acc | p, 0);
 	}
+
+	static getAllIntentsApartFromPresence(): BitFieldResolvable<IntentsString, number> {
+		// Stole... copied from an older version of discord.js...
+		// https://github.com/discordjs/discord.js/blob/51551f544b80d7d27ab0b315da01dfc560b2c115/src/util/Intents.js#L75
+		return Object.values(Intents.FLAGS).reduce((acc, p) => {
+			// Presence updates seem to send GuildMembers without joinedAt, we assume
+			// it's being cached without this field making it null and causing issues down the line.
+			// If we do not listen on this intent, it *may* not get partially cached
+			// https://github.com/discordjs/discord.js/issues/3533
+			if (p === Intents.FLAGS.GUILD_PRESENCES) return acc;
+
+			return acc | p
+		}, 0);
+	}
 }
 
 export default DiscordUtils;

--- a/src/utils/DiscordUtils.ts
+++ b/src/utils/DiscordUtils.ts
@@ -38,12 +38,14 @@ class DiscordUtils {
 		// https://github.com/discordjs/discord.js/blob/51551f544b80d7d27ab0b315da01dfc560b2c115/src/util/Intents.js#L75
 		return Object.values(Intents.FLAGS).reduce((acc, p) => {
 			// Presence updates seem to send GuildMembers without joinedAt, we assume
-			// it's being cached without this field making it null and causing issues down the line.
+			// It's being cached without this field making it null and causing issues down the line.
 			// If we do not listen on this intent, it *may* not get partially cached
 			// https://github.com/discordjs/discord.js/issues/3533
-			if (p === Intents.FLAGS.GUILD_PRESENCES) return acc;
+			if (p === Intents.FLAGS.GUILD_PRESENCES) {
+				return acc;
+			}
 
-			return acc | p
+			return acc | p;
 		}, 0);
 	}
 }


### PR DESCRIPTION
### Overview
Please bullet point the changes you have made below:
- Adds a new method `getAllIntentsApartFromPresence` to `DiscordUtils` to generate intents without the presence intent
- Changes the bot so that it doesn't listen to presence intent
    - The rationale for this is based on a bit of a hunch, but, reading https://github.com/discordjs/discord.js/issues/3533 it seems as though the presence intent causes a `GuildMember` object to come back without a `joinedAt` attribute. In the bot we are assuming this is always present, so if there is a presence update and the member has been cached we are running into an issue where the cached GuildMember does not have this attribute. In theory if we stop listening to this presence and cache the GuildMember in the proper way we may resolve some of the crashing we are currently seeing
