### PR TITLE
Use Discord formatted timestamp

### DIFF
--- a/src/commands/slash/InspectCommand.ts
+++ b/src/commands/slash/InspectCommand.ts
@@ -1,8 +1,7 @@
 import {Discord, Slash, SlashOption} from "discordx";
-import {MessageEmbed, ColorResolvable, CommandInteraction, GuildMember} from "discord.js";
+import {MessageEmbed, ColorResolvable, CommandInteraction, GuildMember, Formatters} from "discord.js";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
-import DateUtils from "../../utils/DateUtils";
 import DiscordUtils from "../../utils/DiscordUtils";
 
 @Discord()
@@ -42,7 +41,12 @@ class InspectCommand {
 
 		if (memberObj?.nickname !== null) embed.addField("Nickname", memberObj?.nickname);
 
-		if (memberObj?.joinedAt !== null) embed.addField("Joined At", DateUtils.formatAsText(memberObj?.joinedAt!));
+		if (memberObj?.joinedAt !== null) {
+			const shortDateTime = Formatters.time(memberObj?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
+			const relativeTime = Formatters.time(memberObj?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
+
+			embed.addField("Joined At", `${shortDateTime} ${relativeTime}`);
+		}
 
 		if (memberObj?.roles.cache.size > 1) {
 			embed.addField("Roles", `${memberObj.roles.cache.filter(role => role.id !== memberObj?.guild!.id).map(role => ` ${role.toString()}`)}`);

--- a/test/commands/slash/InspectCommandTest.ts
+++ b/test/commands/slash/InspectCommandTest.ts
@@ -1,6 +1,6 @@
 import { createSandbox, SinonSandbox } from "sinon";
 import { expect } from "chai";
-import { Collection, EmbedField, GuildMember, GuildMemberRoleManager, Role } from "discord.js";
+import { Collection, EmbedField, GuildMember, GuildMemberRoleManager, Role, Formatters } from "discord.js";
 import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import InspectCommand from "../../../src/commands/slash/InspectCommand";
@@ -53,6 +53,8 @@ describe("InspectCommand", () => {
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
+			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
+			const relativeTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
@@ -63,7 +65,7 @@ describe("InspectCommand", () => {
 			expect(embed.fields[2].name).to.equal("Nickname");
 			expect(embed.fields[2].value).to.equal("my name");
 			expect(embed.fields[3].name).to.equal("Joined At");
-			expect(embed.fields[3].value).to.equal(DateUtils.formatAsText(member.joinedAt!));
+			expect(embed.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
 			expect(embed.fields[4].name).to.equal("Roles");
 			expect(embed.fields[4].value).to.equal(" <@&12345>");
 			expect(embed.hexColor).to.equal(member.displayColor);
@@ -81,13 +83,15 @@ describe("InspectCommand", () => {
 			await command.onInteract(undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
+			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
+			const relativeTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
 			expect(embed.fields.find((field: EmbedField) => field.name === "User ID")?.value).to.equal(member.user.id);
 			expect(embed.fields.find((field: EmbedField) => field.name === "Username")?.value).to.equal(member.user.tag);
 			expect(embed.fields.find((field: EmbedField) => field.name === "Nickname")?.value ?? null).to.equal(member?.nickname);
-			expect(embed.fields.find((field: EmbedField) => field.name === "Joined At")?.value ?? null).to.equal(DateUtils.formatAsText(member!.joinedAt!));
+			expect(embed.fields.find((field: EmbedField) => field.name === "Joined At")?.value ?? null).to.equal(`${shortDateTime} ${relativeTime}`);
 			expect(embed.fields.find((field: EmbedField) => field.name === "Roles")?.value).to.equal(" <@&12345>");
 			expect(embed.hexColor).to.equal(member.displayColor);
 		});
@@ -103,6 +107,8 @@ describe("InspectCommand", () => {
 			await command.onInteract(member.user.username, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
+			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
+			const relativeTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
@@ -113,7 +119,7 @@ describe("InspectCommand", () => {
 			expect(embed.fields[2].name).to.equal("Nickname");
 			expect(embed.fields[2].value).to.equal("my name");
 			expect(embed.fields[3].name).to.equal("Joined At");
-			expect(embed.fields[3].value).to.equal(DateUtils.formatAsText(member.joinedAt!));
+			expect(embed.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
 			expect(embed.fields[4].name).to.equal("Roles");
 			expect(embed.fields[4].value).to.equal("No roles");
 			expect(embed.hexColor).to.equal("#1555b7");


### PR DESCRIPTION
Resolves #233 

### Overview
Please bullet point the changes you have made below:
- Updated the `Joined At` field to use the Discord formatted timestamp

Preview

![image](https://user-images.githubusercontent.com/60689309/175789911-31970843-708d-4835-a7de-9cab7c57214f.png)
