### PR TITLE
Allow Deployments to Rover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+CMD ["npm", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-worker: npm run start

--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,4 @@
+{
+    "schemaVersion": 2,
+    "dockerfilePath": "./Dockerfile"
+}


### PR DESCRIPTION
Removes Heroku's `Procfile` in favour of a `Dockerfile` and `captain-definition` 