### PR TITLE
Adds channels in config.json that are exempt from the file extension restrictions

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -36,6 +36,9 @@
         "DEFAULT": "#1555B7",
         "WARNING": "#F7CE61"
     },
+    "EXEMPT_CHANNELS_FILE_RESTRICTIONS": [
+        "495713774205141022"
+    ],
     "ALLOWED_FILE_EXTENSIONS": [
         "jpg",
         "jpeg",

--- a/src/event/handlers/CodeblocksOverFileUploadsHandler.ts
+++ b/src/event/handlers/CodeblocksOverFileUploadsHandler.ts
@@ -9,6 +9,8 @@ class CodeblocksOverFileUploadsHandler extends EventHandler {
 	}
 
 	async handle(message: Message): Promise<void> {
+		if (getConfigValue<string[]>("EXEMPT_CHANNELS_FILE_RESTRICTIONS").includes(message.channelId)) return;
+
 		let invalidFileFlag = false;
 		let invalidFileExtension: string = "";
 

--- a/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
+++ b/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
@@ -3,7 +3,7 @@ import { Collection, Constants, Message, MessageAttachment } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
-import { EMBED_COLOURS } from "../../../src/config.json";
+import { EMBED_COLOURS, MOD_CHANNEL_ID } from "../../../src/config.json";
 import EventHandler from "../../../src/abstracts/EventHandler";
 import CodeblocksOverFileUploadsHandler from "../../../src/event/handlers/CodeblocksOverFileUploadsHandler";
 
@@ -42,6 +42,15 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 
 		it("does nothing when there is a valid attachment.", async () => {
 			message.attachments.set("720390958847361064", new MessageAttachment("720390958847361064", "test.png"));
+			const addMockSend = sandbox.stub(message.channel, "send");
+
+			await handler.handle(message);
+			expect(addMockSend.notCalled).to.be.true;
+		});
+
+		it("does nothing when a not allowed extension is uploaded in an exempt channel.", async () => {
+			message.attachments.set("720390958847361065", new MessageAttachment("720390958847361065", "test.exe"));
+			message.channelId = MOD_CHANNEL_ID;
 			const addMockSend = sandbox.stub(message.channel, "send");
 
 			await handler.handle(message);


### PR DESCRIPTION
Resolves #260 

### Overview
- Added an array to config.json where channel IDs can be added that are exempt from the file restrictions, currently only has the mod channel in it

