### PR TITLE
The big one: upgrade Discord.js and DiscordX to latest versions (upgrade from v13 to v14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class CodeblockCommand {
     async onInteract(
         @SlashOption("year", {type: "NUMBER"}) year: number,
             interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
         embed.setTitle("Happy new year!");
         embed.setDescription(`Welcome to the year ${year}, may all your wishes come true!`);

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To create an event handler, create a new file in `src/event/handlers` named `<Ha
 ```ts
 class ExampleHandler extends EventHandler {
     constructor() {
-        super(Constants.Events.MESSAGE_CREATE);
+        super(Events.MessageCreate);
     }
 
     async handle(message: Message): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/assert": "^1.5.2",
         "@types/chai": "^4.2.14",
         "@types/mocha": "^7.0.2",
-        "@types/node": "^17.0.8",
+        "@types/node": "^18.14.6",
         "@types/node-schedule": "^1.3.2",
         "@types/sinon": "^9.0.8",
         "@types/ws": "^7.4.0",
@@ -39,8 +39,8 @@
         "nyc": "^15.1.0",
         "sinon": "^9.2.1",
         "ts-mocha": "^7.0.0",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.5.4"
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": ">=16.9.0",
@@ -398,6 +398,28 @@
       "engines": {
         "node": ">=16.6.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -789,6 +811,30 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "node_modules/@types/assert": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.6.tgz",
@@ -821,9 +867,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -1064,6 +1110,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -5674,29 +5729,58 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ts-node/node_modules/diff": {
@@ -5942,6 +6026,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/webidl-conversions": {
@@ -6534,6 +6624,27 @@
       "resolved": "https://registry.npmjs.org/@codesupport/inherited-config/-/inherited-config-1.0.2.tgz",
       "integrity": "sha512-IuVxRuTUj0Ck2rRN5PpN6wi+ZQSJIKY9J+B2HVw1kguBtjhQDZVpAH4GwVms2aG+6/xLw7szVIiGvqzzl85vSw=="
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@discordjs/builders": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
@@ -6541,7 +6652,7 @@
       "requires": {
         "@discordjs/util": "^0.1.0",
         "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "0.37.20",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.2",
         "tslib": "^2.4.1"
@@ -6561,7 +6672,7 @@
         "@discordjs/util": "^0.1.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "0.37.20",
+        "discord-api-types": "^0.37.23",
         "file-type": "^18.0.0",
         "tslib": "^2.4.1",
         "undici": "^5.13.0"
@@ -6713,7 +6824,7 @@
           "dev": true,
           "requires": {
             "@sapphire/shapeshift": "^3.5.1",
-            "discord-api-types": "0.37.20",
+            "discord-api-types": "^0.36.2",
             "fast-deep-equal": "^3.1.3",
             "ts-mixer": "^6.0.1",
             "tslib": "^2.4.0"
@@ -6838,6 +6949,30 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/assert": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.6.tgz",
@@ -6870,9 +7005,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -7031,6 +7166,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -10422,19 +10563,32 @@
       }
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+          "dev": true
+        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -10624,6 +10778,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@codesupport/inherited-config": "^1.0.2",
         "axios": "^0.21.2",
         "axios-cache-adapter": "^2.5.0",
-        "discord.js": "^14.7.1",
+        "discord.js": "^14.8.0",
         "discordx": "^11.7.1",
         "dotenv": "^8.2.0",
         "node-schedule": "^2.1.0",
@@ -20,7 +20,7 @@
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
-        "@lambocreeper/mock-discord.js": "^2.0.1",
+        "@lambocreeper/mock-discord.js": "^3.0.0",
         "@types/assert": "^1.5.2",
         "@types/chai": "^4.2.14",
         "@types/mocha": "^7.0.2",
@@ -423,51 +423,63 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
-      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.5.0.tgz",
+      "integrity": "sha512-7XxT78mnNBPigHn2y6KAXkicxIBFtZREGWaRZ249EC1l6gBUEP8IyVY5JTciIjJArxkF+tg675aZvsTNTKBpmA==",
       "dependencies": {
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/shapeshift": "^3.8.1",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.2",
-        "tslib": "^2.4.1"
+        "ts-mixer": "^6.0.3",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
-      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.4.0.tgz",
+      "integrity": "sha512-hiOJyk2CPFf1+FL3a4VKCuu1f448LlROVuu8nLz1+jCOAPokUcdFAV+l4pd3B3h6uJlJQSASoZzrdyNdjdtfzQ==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.2.0.tgz",
+      "integrity": "sha512-vn4oMSXuMZUm8ITqVOtvE7/fMMISj4cI5oLsR09PEQXHKeKDAMLltG/DWeeIs7Idfy6V8Fk3rn1e69h7NfzuNA==",
+      "dependencies": {
+        "discord-api-types": "^0.37.35"
+      },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
-      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.6.0.tgz",
+      "integrity": "sha512-HGvqNCZ5Z5j0tQHjmT1lFvE5ETO4hvomJ1r0cbnpC1zM23XhCpZ9wgTCiEmaxKz05cyf2CI9p39+9LL+6Yz1bA==",
       "dependencies": {
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/util": "^0.1.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/util": "^0.2.0",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.23",
-        "file-type": "^18.0.0",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0"
+        "@sapphire/snowflake": "^3.4.0",
+        "discord-api-types": "^0.37.35",
+        "file-type": "^18.2.1",
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -640,69 +652,12 @@
       }
     },
     "node_modules/@lambocreeper/mock-discord.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lambocreeper/mock-discord.js/-/mock-discord.js-2.0.1.tgz",
-      "integrity": "sha512-wkPtM05h/t0Y9tlvW8Xixrpo7yEt68ASvdkVyFSCNBsgrcVMjGeoZQVBucHg3+/7OsI5JOdzCG7fdVAbKG3HCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@lambocreeper/mock-discord.js/-/mock-discord.js-3.0.0.tgz",
+      "integrity": "sha512-EP1OwCkIvEwzKRjq0ZOnJjLwpKYvcfDDWYE7+ymTO1OfSCwp7RtBVzjD7o5AzXggFWquiUUu9ajCehQ7R5ndjg==",
       "dev": true,
       "dependencies": {
-        "discord.js": "^13.0.1"
-      }
-    },
-    "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/builders": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
-      "deprecated": "no longer supported",
-      "dev": true,
-      "dependencies": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.36.2",
-        "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-      "deprecated": "no longer supported",
-      "dev": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/@lambocreeper/mock-discord.js/node_modules/@types/ws": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@lambocreeper/mock-discord.js/node_modules/discord.js": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
-      "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
-      "dev": true,
-      "dependencies": {
-        "@discordjs/builders": "^0.16.0",
-        "@discordjs/collection": "^0.7.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/node-fetch": "^2.6.2",
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.33.5",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.7",
-        "ws": "^8.9.0"
-      },
-      "engines": {
-        "node": ">=16.6.0",
-        "npm": ">=7.0.0"
+        "discord.js": "^14.8.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -870,30 +825,6 @@
       "version": "18.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
       "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/@types/node-schedule": {
       "version": "1.3.2",
@@ -1308,12 +1239,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1662,18 +1587,6 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1824,15 +1737,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1855,27 +1759,28 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.20",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
-      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
+      "version": "0.37.36",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.36.tgz",
+      "integrity": "sha512-Nlxmp10UpVr/utgZ9uODQvG2Or+5w7LFrvFMswyeKC9l/+UaqGT6H0OVgEFhu9GEO4U6K7NNO5W8Carv7irnCA=="
     },
     "node_modules/discord.js": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
-      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.8.0.tgz",
+      "integrity": "sha512-UOxYtc/YnV7jAJ2gISluJyYeBw4e+j8gWn+IoqG8unaHAVuvZ13DdYN0M1f9fbUgUvSarV798inIrYFtDNDjwQ==",
       "dependencies": {
-        "@discordjs/builders": "^1.4.0",
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/rest": "^1.4.0",
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/builders": "^1.5.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/rest": "^1.6.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/snowflake": "^3.4.0",
+        "@types/ws": "^8.5.4",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0",
-        "ws": "^8.11.0"
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0",
+        "ws": "^8.12.1"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -2610,20 +2515,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fromentries": {
@@ -3847,27 +3738,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -4093,26 +3963,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-preload": {
@@ -4898,9 +4748,9 @@
       ]
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5665,12 +5515,6 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/ts-mixer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
@@ -5963,9 +5807,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -6033,22 +5877,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6646,42 +6474,51 @@
       }
     },
     "@discordjs/builders": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
-      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.5.0.tgz",
+      "integrity": "sha512-7XxT78mnNBPigHn2y6KAXkicxIBFtZREGWaRZ249EC1l6gBUEP8IyVY5JTciIjJArxkF+tg675aZvsTNTKBpmA==",
       "requires": {
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "^0.37.20",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/shapeshift": "^3.8.1",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.2",
-        "tslib": "^2.4.1"
+        "ts-mixer": "^6.0.3",
+        "tslib": "^2.5.0"
       }
     },
     "@discordjs/collection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
-      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.4.0.tgz",
+      "integrity": "sha512-hiOJyk2CPFf1+FL3a4VKCuu1f448LlROVuu8nLz1+jCOAPokUcdFAV+l4pd3B3h6uJlJQSASoZzrdyNdjdtfzQ=="
+    },
+    "@discordjs/formatters": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.2.0.tgz",
+      "integrity": "sha512-vn4oMSXuMZUm8ITqVOtvE7/fMMISj4cI5oLsR09PEQXHKeKDAMLltG/DWeeIs7Idfy6V8Fk3rn1e69h7NfzuNA==",
+      "requires": {
+        "discord-api-types": "^0.37.35"
+      }
     },
     "@discordjs/rest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
-      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.6.0.tgz",
+      "integrity": "sha512-HGvqNCZ5Z5j0tQHjmT1lFvE5ETO4hvomJ1r0cbnpC1zM23XhCpZ9wgTCiEmaxKz05cyf2CI9p39+9LL+6Yz1bA==",
       "requires": {
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/util": "^0.1.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/util": "^0.2.0",
         "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.23",
-        "file-type": "^18.0.0",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0"
+        "@sapphire/snowflake": "^3.4.0",
+        "discord-api-types": "^0.37.35",
+        "file-type": "^18.2.1",
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0"
       }
     },
     "@discordjs/util": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
-      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.2.0.tgz",
+      "integrity": "sha512-/8qNbebFzLWKOOg+UV+RB8itp4SmU5jw0tBUD3ifElW6rYNOj1Ku5JaSW7lLl/WgjjxF01l/1uQPCzkwr110vg=="
     },
     "@discordx/di": {
       "version": "3.0.3",
@@ -6809,59 +6646,12 @@
       }
     },
     "@lambocreeper/mock-discord.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lambocreeper/mock-discord.js/-/mock-discord.js-2.0.1.tgz",
-      "integrity": "sha512-wkPtM05h/t0Y9tlvW8Xixrpo7yEt68ASvdkVyFSCNBsgrcVMjGeoZQVBucHg3+/7OsI5JOdzCG7fdVAbKG3HCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@lambocreeper/mock-discord.js/-/mock-discord.js-3.0.0.tgz",
+      "integrity": "sha512-EP1OwCkIvEwzKRjq0ZOnJjLwpKYvcfDDWYE7+ymTO1OfSCwp7RtBVzjD7o5AzXggFWquiUUu9ajCehQ7R5ndjg==",
       "dev": true,
       "requires": {
-        "discord.js": "^13.0.1"
-      },
-      "dependencies": {
-        "@discordjs/builders": {
-          "version": "0.16.0",
-          "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-          "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
-          "dev": true,
-          "requires": {
-            "@sapphire/shapeshift": "^3.5.1",
-            "discord-api-types": "^0.36.2",
-            "fast-deep-equal": "^3.1.3",
-            "ts-mixer": "^6.0.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@discordjs/collection": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-          "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-          "dev": true
-        },
-        "@types/ws": {
-          "version": "8.5.4",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-          "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "discord.js": {
-          "version": "13.13.1",
-          "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
-          "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
-          "dev": true,
-          "requires": {
-            "@discordjs/builders": "^0.16.0",
-            "@discordjs/collection": "^0.7.0",
-            "@sapphire/async-queue": "^1.5.0",
-            "@types/node-fetch": "^2.6.2",
-            "@types/ws": "^8.5.3",
-            "discord-api-types": "0.37.20",
-            "form-data": "^4.0.0",
-            "node-fetch": "^2.6.7",
-            "ws": "^8.9.0"
-          }
-        }
+        "discord.js": "^14.8.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -7008,29 +6798,6 @@
       "version": "18.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
       "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA=="
-    },
-    "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
     },
     "@types/node-schedule": {
       "version": "1.3.2",
@@ -7310,12 +7077,6 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -7578,15 +7339,6 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -7693,12 +7445,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -7715,27 +7461,28 @@
       }
     },
     "discord-api-types": {
-      "version": "0.37.20",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
-      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
+      "version": "0.37.36",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.36.tgz",
+      "integrity": "sha512-Nlxmp10UpVr/utgZ9uODQvG2Or+5w7LFrvFMswyeKC9l/+UaqGT6H0OVgEFhu9GEO4U6K7NNO5W8Carv7irnCA=="
     },
     "discord.js": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
-      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.8.0.tgz",
+      "integrity": "sha512-UOxYtc/YnV7jAJ2gISluJyYeBw4e+j8gWn+IoqG8unaHAVuvZ13DdYN0M1f9fbUgUvSarV798inIrYFtDNDjwQ==",
       "requires": {
-        "@discordjs/builders": "^1.4.0",
-        "@discordjs/collection": "^1.3.0",
-        "@discordjs/rest": "^1.4.0",
-        "@discordjs/util": "^0.1.0",
-        "@sapphire/snowflake": "^3.2.2",
-        "@types/ws": "^8.5.3",
-        "discord-api-types": "0.37.20",
+        "@discordjs/builders": "^1.5.0",
+        "@discordjs/collection": "^1.4.0",
+        "@discordjs/formatters": "^0.2.0",
+        "@discordjs/rest": "^1.6.0",
+        "@discordjs/util": "^0.2.0",
+        "@sapphire/snowflake": "^3.4.0",
+        "@types/ws": "^8.5.4",
+        "discord-api-types": "^0.37.35",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.4.1",
-        "undici": "^5.13.0",
-        "ws": "^8.11.0"
+        "tslib": "^2.5.0",
+        "undici": "^5.20.0",
+        "ws": "^8.12.1"
       },
       "dependencies": {
         "@types/ws": {
@@ -8282,17 +8029,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "fromentries": {
@@ -9172,21 +8908,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.52.0"
-      }
-    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -9371,15 +9092,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
       }
     },
     "node-preload": {
@@ -9948,9 +9660,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10517,12 +10229,6 @@
         "nopt": "~1.0.10"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "ts-mixer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
@@ -10737,9 +10443,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "requires": {
         "busboy": "^1.6.0"
       }
@@ -10785,22 +10491,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@codesupport/inherited-config": "^1.0.2",
         "axios": "^0.21.2",
         "axios-cache-adapter": "^2.5.0",
-        "discord.js": "^13.9.0",
-        "discordx": "^9.9.0",
+        "discord.js": "^14.0.3",
+        "discordx": "^10.0.0",
         "dotenv": "^8.2.0",
         "node-schedule": "^2.1.0",
         "reflect-metadata": "^0.1.13"
@@ -404,31 +404,51 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
-      "deprecated": "no longer supported",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "dependencies": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.36.2",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       },
       "engines": {
         "node": ">=16.9.0"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-    },
     "node_modules/@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-      "deprecated": "no longer supported",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "dependencies": {
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@sapphire/snowflake": "^3.2.2",
+        "discord-api-types": "^0.37.23",
+        "file-type": "^18.0.0",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -564,6 +584,75 @@
         "discord.js": "^13.0.1"
       }
     },
+    "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/builders": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+      "deprecated": "no longer supported",
+      "dev": true,
+      "dependencies": {
+        "@sapphire/shapeshift": "^3.5.1",
+        "discord-api-types": "^0.36.2",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+      "dev": true
+    },
+    "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/collection": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+      "deprecated": "no longer supported",
+      "dev": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@lambocreeper/mock-discord.js/node_modules/@types/ws": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@lambocreeper/mock-discord.js/node_modules/discord-api-types": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==",
+      "dev": true
+    },
+    "node_modules/@lambocreeper/mock-discord.js/node_modules/discord.js": {
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
+      "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
+      "dev": true,
+      "dependencies": {
+        "@discordjs/builders": "^0.16.0",
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/node-fetch": "^2.6.2",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.33.5",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.7",
+        "ws": "^8.9.0"
+      },
+      "engines": {
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -621,6 +710,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -656,6 +754,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "node_modules/@types/assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.5.tgz",
@@ -689,6 +792,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -698,6 +802,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1112,7 +1217,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/axios": {
       "version": "0.21.2",
@@ -1205,6 +1311,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/cache-control-esm": {
       "version": "1.0.0",
@@ -1436,6 +1553,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1592,7 +1710,8 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1619,28 +1738,30 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+      "version": "0.37.35",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
+      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
     },
     "node_modules/discord.js": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
-      "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "dependencies": {
-        "@discordjs/builders": "^0.16.0",
-        "@discordjs/collection": "^0.7.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/node-fetch": "^2.6.2",
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.33.5",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.7",
-        "ws": "^8.9.0"
+        "discord-api-types": "^0.37.20",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.snakecase": "^4.1.1",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       },
       "engines": {
-        "node": ">=16.6.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/discord.js/node_modules/@types/ws": {
@@ -1652,13 +1773,12 @@
       }
     },
     "node_modules/discordx": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/discordx/-/discordx-9.9.0.tgz",
-      "integrity": "sha512-wm93OgIQ96BPDu3wQdQlc5NjihaE8fsEy0mMWr2qfPGuuw+qq0cGSOnXwxIhtWH9hVPPHyeEj2fuADF9rHy/UQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/discordx/-/discordx-10.0.0.tgz",
+      "integrity": "sha512-RPjegdLE/w7uRr4brAdhqRMfMsu8458HIOoFrt04QOdLDlTqWzQBlxV1qxQ3WsC3o4jEt5jkJaMdMYXIvcBSrQ==",
       "dependencies": {
         "@discordx/di": "^2.0.1",
         "@discordx/internal": "^1.0.2",
-        "discord-api-types": "^0.33.3",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.4.0"
@@ -1668,7 +1788,7 @@
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "discord.js": ">=13 || ^13.0.0-dev"
+        "discord.js": ">=14 || ^14.0.0-dev"
       }
     },
     "node_modules/doctrine": {
@@ -2169,6 +2289,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/file-type": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2301,6 +2437,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2597,6 +2734,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2659,8 +2815,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inquirer": {
       "version": "7.3.3",
@@ -3279,6 +3434,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
     "node_modules/log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -3379,19 +3539,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -3598,9 +3760,10 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4255,6 +4418,18 @@
         "node": "*"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4389,6 +4564,34 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.2.0",
@@ -4786,6 +4989,41 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -4878,6 +5116,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -5015,6 +5269,22 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -5030,7 +5300,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/ts-mixer": {
       "version": "6.0.3",
@@ -5266,6 +5537,17 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5274,6 +5556,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -5294,12 +5581,14 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -5861,28 +6150,42 @@
       "integrity": "sha512-IuVxRuTUj0Ck2rRN5PpN6wi+ZQSJIKY9J+B2HVw1kguBtjhQDZVpAH4GwVms2aG+6/xLw7szVIiGvqzzl85vSw=="
     },
     "@discordjs/builders": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.4.0.tgz",
+      "integrity": "sha512-nEeTCheTTDw5kO93faM1j8ZJPonAX86qpq/QVoznnSa8WWcCgJpjlu6GylfINTDW6o7zZY0my2SYdxx2mfNwGA==",
       "requires": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.36.2",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.1",
+        "discord-api-types": "^0.37.20",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.1",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.36.3",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-        }
+        "ts-mixer": "^6.0.2",
+        "tslib": "^2.4.1"
       }
     },
     "@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.3.0.tgz",
+      "integrity": "sha512-ylt2NyZ77bJbRij4h9u/wVy7qYw/aDqQLWnadjvDqW/WoWCxrsX6M3CIw9GVP5xcGCDxsrKj5e0r5evuFYwrKg=="
+    },
+    "@discordjs/rest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.5.0.tgz",
+      "integrity": "sha512-lXgNFqHnbmzp5u81W0+frdXN6Etf4EUi8FAPcWpSykKd8hmlWh1xy6BmE0bsJypU1pxohaA8lQCgp70NUI3uzA==",
+      "requires": {
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@sapphire/snowflake": "^3.2.2",
+        "discord-api-types": "^0.37.23",
+        "file-type": "^18.0.0",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0"
+      }
+    },
+    "@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
     },
     "@discordx/di": {
       "version": "2.0.1",
@@ -5978,6 +6281,67 @@
       "dev": true,
       "requires": {
         "discord.js": "^13.0.1"
+      },
+      "dependencies": {
+        "@discordjs/builders": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+          "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+          "dev": true,
+          "requires": {
+            "@sapphire/shapeshift": "^3.5.1",
+            "discord-api-types": "^0.36.2",
+            "fast-deep-equal": "^3.1.3",
+            "ts-mixer": "^6.0.1",
+            "tslib": "^2.4.0"
+          },
+          "dependencies": {
+            "discord-api-types": {
+              "version": "0.36.3",
+              "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+              "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
+              "dev": true
+            }
+          }
+        },
+        "@discordjs/collection": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+          "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+          "dev": true
+        },
+        "@types/ws": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+          "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "discord-api-types": {
+          "version": "0.33.5",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+          "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==",
+          "dev": true
+        },
+        "discord.js": {
+          "version": "13.13.1",
+          "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
+          "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
+          "dev": true,
+          "requires": {
+            "@discordjs/builders": "^0.16.0",
+            "@discordjs/collection": "^0.7.0",
+            "@sapphire/async-queue": "^1.5.0",
+            "@types/node-fetch": "^2.6.2",
+            "@types/ws": "^8.5.3",
+            "discord-api-types": "^0.33.5",
+            "form-data": "^4.0.0",
+            "node-fetch": "^2.6.7",
+            "ws": "^8.9.0"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -6020,6 +6384,11 @@
         "lodash": "^4.17.21"
       }
     },
+    "@sapphire/snowflake": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.4.0.tgz",
+      "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -6055,6 +6424,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@types/assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.5.tgz",
@@ -6088,6 +6462,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -6097,6 +6472,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
           "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -6379,7 +6755,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "axios": {
       "version": "0.21.2",
@@ -6453,6 +6830,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "cache-control-esm": {
       "version": "1.0.0",
@@ -6638,6 +7023,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -6753,7 +7139,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -6771,24 +7158,27 @@
       }
     },
     "discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+      "version": "0.37.35",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
+      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
     },
     "discord.js": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
-      "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.7.1.tgz",
+      "integrity": "sha512-1FECvqJJjjeYcjSm0IGMnPxLqja/pmG1B0W2l3lUY2Gi4KXiyTeQmU1IxWcbXHn2k+ytP587mMWqva2IA87EbA==",
       "requires": {
-        "@discordjs/builders": "^0.16.0",
-        "@discordjs/collection": "^0.7.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/node-fetch": "^2.6.2",
+        "@discordjs/builders": "^1.4.0",
+        "@discordjs/collection": "^1.3.0",
+        "@discordjs/rest": "^1.4.0",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.33.5",
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.6.7",
-        "ws": "^8.9.0"
+        "discord-api-types": "^0.37.20",
+        "fast-deep-equal": "^3.1.3",
+        "lodash.snakecase": "^4.1.1",
+        "tslib": "^2.4.1",
+        "undici": "^5.13.0",
+        "ws": "^8.11.0"
       },
       "dependencies": {
         "@types/ws": {
@@ -6802,13 +7192,12 @@
       }
     },
     "discordx": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/discordx/-/discordx-9.9.0.tgz",
-      "integrity": "sha512-wm93OgIQ96BPDu3wQdQlc5NjihaE8fsEy0mMWr2qfPGuuw+qq0cGSOnXwxIhtWH9hVPPHyeEj2fuADF9rHy/UQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/discordx/-/discordx-10.0.0.tgz",
+      "integrity": "sha512-RPjegdLE/w7uRr4brAdhqRMfMsu8458HIOoFrt04QOdLDlTqWzQBlxV1qxQ3WsC3o4jEt5jkJaMdMYXIvcBSrQ==",
       "requires": {
         "@discordx/di": "^2.0.1",
         "@discordx/internal": "^1.0.2",
-        "discord-api-types": "^0.33.3",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.4.0"
@@ -7202,6 +7591,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-type": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.2.1.tgz",
+      "integrity": "sha512-Yw5MtnMv7vgD2/6Bjmmuegc8bQEVA9GmAyaR18bMYWKqsWDG9wgYZ1j4I6gNMF5Y5JBDcUcjRQqNQx7Y8uotcg==",
+      "requires": {
+        "readable-web-to-node-stream": "^3.0.2",
+        "strtok3": "^7.0.0",
+        "token-types": "^5.0.1"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -7284,6 +7683,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7485,6 +7885,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -7532,8 +7937,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
       "version": "7.3.3",
@@ -7988,6 +8392,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -8066,16 +8475,18 @@
       }
     },
     "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
     },
     "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "requires": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -8247,9 +8658,10 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -8725,6 +9137,11 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
+    "peek-readable": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
+      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -8814,6 +9231,24 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -9117,6 +9552,26 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -9185,6 +9640,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strtok3": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
+      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.0.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -9295,6 +9759,15 @@
         "is-number": "^7.0.0"
       }
     },
+    "token-types": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
+      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -9307,7 +9780,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "ts-mixer": {
       "version": "6.0.3",
@@ -9487,6 +9961,14 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9495,6 +9977,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "3.4.0",
@@ -9511,12 +9998,14 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "discord-bot",
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@codesupport/inherited-config": "^1.0.2",
         "axios": "^0.21.2",
         "axios-cache-adapter": "^2.5.0",
-        "discord.js": "^13.5.0",
-        "discordx": "^9.1.7",
+        "discord.js": "^13.9.0",
+        "discordx": "^9.9.0",
         "dotenv": "^8.2.0",
         "node-schedule": "^2.1.0",
         "reflect-metadata": "^0.1.13"
@@ -403,28 +404,33 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+      "deprecated": "no longer supported",
       "dependencies": {
-        "@sindresorhus/is": "^4.2.0",
-        "discord-api-types": "^0.26.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.1",
-        "zod": "^3.11.6"
+        "@sapphire/shapeshift": "^3.5.1",
+        "discord-api-types": "^0.36.2",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.4.0"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
     },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+    },
     "node_modules/@discordjs/collection": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+      "deprecated": "no longer supported",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@discordx/di": {
@@ -594,23 +600,25 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
-      "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==",
-      "engines": {
-        "node": ">=10"
+    "node_modules/@sapphire/shapeshift": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
       },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -678,9 +686,9 @@
       "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -1611,27 +1619,24 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "node_modules/discord.js": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.5.0.tgz",
-      "integrity": "sha512-K+ZcB0f+wA1ZzDhz3hlaAi4Ap7jSvVEUZ+U29T4DMoiNNUv22F4vu1byrOq8GyyLLDFiZ3iSudea0MvSHu3fQA==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
+      "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
       "dependencies": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.16.0",
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/node-fetch": "^2.6.2",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.33.5",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "node-fetch": "^2.6.7",
+        "ws": "^8.9.0"
       },
       "engines": {
         "node": ">=16.6.0",
@@ -1639,23 +1644,24 @@
       }
     },
     "node_modules/discord.js/node_modules/@types/ws": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/discordx": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/discordx/-/discordx-9.5.1.tgz",
-      "integrity": "sha512-MTArqCxI73uRC9ox0OgSar1E12PozFudzVqB8OXVj1NA/K/EFq6EFbBwV0MmST3Dvdw/OdJveT0Sl5z8cEl6qA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/discordx/-/discordx-9.9.0.tgz",
+      "integrity": "sha512-wm93OgIQ96BPDu3wQdQlc5NjihaE8fsEy0mMWr2qfPGuuw+qq0cGSOnXwxIhtWH9hVPPHyeEj2fuADF9rHy/UQ==",
       "dependencies": {
         "@discordx/di": "^2.0.1",
         "@discordx/internal": "^1.0.2",
+        "discord-api-types": "^0.33.3",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -2097,8 +2103,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.7",
@@ -5028,9 +5033,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "node_modules/ts-mocha": {
       "version": "7.0.0",
@@ -5142,9 +5147,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -5472,15 +5477,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -5581,14 +5586,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   },
@@ -5864,21 +5861,28 @@
       "integrity": "sha512-IuVxRuTUj0Ck2rRN5PpN6wi+ZQSJIKY9J+B2HVw1kguBtjhQDZVpAH4GwVms2aG+6/xLw7szVIiGvqzzl85vSw=="
     },
     "@discordjs/builders": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
+      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
       "requires": {
-        "@sindresorhus/is": "^4.2.0",
-        "discord-api-types": "^0.26.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.1",
-        "zod": "^3.11.6"
+        "@sapphire/shapeshift": "^3.5.1",
+        "discord-api-types": "^0.36.2",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.36.3",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+        }
       }
     },
     "@discordjs/collection": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
     },
     "@discordx/di": {
       "version": "2.0.1",
@@ -6003,14 +6007,18 @@
       }
     },
     "@sapphire/async-queue": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
     },
-    "@sindresorhus/is": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
-      "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w=="
+    "@sapphire/shapeshift": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.8.1.tgz",
+      "integrity": "sha512-xG1oXXBhCjPKbxrRTlox9ddaZTvVpOhYLmKmApD/vIWOV1xEYXnpoFs68zHIZBGbqztq6FrUPNPerIrO1Hqeaw==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      }
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -6077,9 +6085,9 @@
       "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
     },
     "@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -6763,30 +6771,30 @@
       }
     },
     "discord-api-types": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "discord.js": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.5.0.tgz",
-      "integrity": "sha512-K+ZcB0f+wA1ZzDhz3hlaAi4Ap7jSvVEUZ+U29T4DMoiNNUv22F4vu1byrOq8GyyLLDFiZ3iSudea0MvSHu3fQA==",
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
+      "integrity": "sha512-4QdeSIGOIeZ25cTOxaPdVqIXz8tN56DetXFAwEkDHX5sDqbsXm9gMaNhfaOwMap3d5mgdC7I78g70I82x5i5lw==",
       "requires": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.16.0",
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.5.0",
+        "@types/node-fetch": "^2.6.2",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.33.5",
         "form-data": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "node-fetch": "^2.6.7",
+        "ws": "^8.9.0"
       },
       "dependencies": {
         "@types/ws": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-          "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+          "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
           "requires": {
             "@types/node": "*"
           }
@@ -6794,15 +6802,16 @@
       }
     },
     "discordx": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/discordx/-/discordx-9.5.1.tgz",
-      "integrity": "sha512-MTArqCxI73uRC9ox0OgSar1E12PozFudzVqB8OXVj1NA/K/EFq6EFbBwV0MmST3Dvdw/OdJveT0Sl5z8cEl6qA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/discordx/-/discordx-9.9.0.tgz",
+      "integrity": "sha512-wm93OgIQ96BPDu3wQdQlc5NjihaE8fsEy0mMWr2qfPGuuw+qq0cGSOnXwxIhtWH9hVPPHyeEj2fuADF9rHy/UQ==",
       "requires": {
         "@discordx/di": "^2.0.1",
         "@discordx/internal": "^1.0.2",
+        "discord-api-types": "^0.33.3",
         "lodash": "^4.17.21",
         "reflect-metadata": "^0.1.13",
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       }
     },
     "doctrine": {
@@ -7139,8 +7148,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -9302,9 +9310,9 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "ts-mixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
+      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
     "ts-mocha": {
       "version": "7.0.0",
@@ -9384,9 +9392,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -9654,9 +9662,9 @@
       }
     },
     "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "requires": {}
     },
     "y18n": {
@@ -9740,11 +9748,6 @@
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
-    },
-    "zod": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@codesupport/inherited-config": "^1.0.2",
         "axios": "^0.21.2",
         "axios-cache-adapter": "^2.5.0",
-        "discord.js": "^14.0.3",
-        "discordx": "^10.0.0",
+        "discord.js": "^14.7.1",
+        "discordx": "^11.7.1",
         "dotenv": "^8.2.0",
         "node-schedule": "^2.1.0",
         "reflect-metadata": "^0.1.13"
@@ -43,52 +43,65 @@
         "typescript": "^4.5.4"
       },
       "engines": {
-        "node": ">=16.6.0",
+        "node": ">=16.9.0",
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
+      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.21.0",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.0",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "json5": "^2.2.2",
+        "semver": "^6.3.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -108,28 +121,44 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
+      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
+        "@babel/types": "^7.21.0",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -148,177 +177,143 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "dev": true,
-      "dependencies": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
-      "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.8",
-        "@babel/types": "^7.14.8"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -327,9 +322,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
-      "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -339,32 +334,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
+      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.21.1",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.21.2",
+        "@babel/types": "^7.21.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -382,12 +378,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -454,11 +451,11 @@
       }
     },
     "node_modules/@discordx/di": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordx/di/-/di-2.0.1.tgz",
-      "integrity": "sha512-aIGd97QJwdMkpANcaErYj0iv25loKdJQulUB1+a83Z3Jm+YVBFI7MHSad5zjdg4GYpGsOV1JW+xHhAwW21IhoA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@discordx/di/-/di-3.0.3.tgz",
+      "integrity": "sha512-aLjThqw6/FJNxHrDXFwiWUnbN5MKnt2Ef99Ry6sH4SiIqbM1MRCSM4nsPxnTuR5+noM9hKD6nYSoNaAGjaMcYQ==",
       "dependencies": {
-        "tsyringe": "^4.6.0",
+        "tsyringe": "^4.7.0",
         "typedi": "^0.10.0"
       },
       "engines": {
@@ -550,9 +547,9 @@
       }
     },
     "node_modules/@istanbuljs/nyc-config-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
-      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
+      "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
       "dev": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2"
@@ -561,9 +558,7 @@
         "node": ">=8"
       },
       "peerDependencies": {
-        "nyc": ">=15",
-        "source-map-support": "*",
-        "ts-node": "*"
+        "nyc": ">=15"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -573,6 +568,53 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@lambocreeper/mock-discord.js": {
@@ -601,12 +643,6 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
-      "dev": true
-    },
     "node_modules/@lambocreeper/mock-discord.js/node_modules/@discordjs/collection": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
@@ -625,12 +661,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@lambocreeper/mock-discord.js/node_modules/discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==",
-      "dev": true
     },
     "node_modules/@lambocreeper/mock-discord.js/node_modules/discord.js": {
       "version": "13.13.1",
@@ -720,9 +750,9 @@
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
@@ -749,9 +779,9 @@
       }
     },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "node_modules/@tokenizer/token": {
@@ -760,22 +790,29 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/assert": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.5.tgz",
-      "integrity": "sha512-myz5KWf6ox66Ou1m0KiLZpitk7W6Vly2LFRx7AXHSLeMUM6bmDIStIBk0xd7I2vXcAQEuhegdpjPuypmP5ui0Q==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.6.tgz",
+      "integrity": "sha512-Y7gDJiIqb9qKUHfBQYOWGngUpLORtirAVPuj/CWJrU2C6ZM4/y3XLwuwfGMF8s7QzW746LQZx23m0+1FSgjfug==",
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
-      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@types/mocha": {
       "version": "7.0.2",
@@ -784,9 +821,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -831,9 +868,9 @@
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-      "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -846,15 +883,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.29.1",
-        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
@@ -876,16 +914,16 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-      "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -900,33 +938,15 @@
         "eslint": "*"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -946,13 +966,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -963,9 +983,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -976,13 +996,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -1003,12 +1023,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -1133,9 +1153,9 @@
       }
     },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1160,7 +1180,7 @@
     "node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "node_modules/arg": {
@@ -1187,10 +1207,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1220,10 +1259,22 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
@@ -1284,26 +1335,31 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/buffer-from": {
@@ -1347,6 +1403,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1374,25 +1431,32 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001460",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz",
+      "integrity": "sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       },
@@ -1423,7 +1487,7 @@
     "node_modules/charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "engines": {
         "node": "*"
       }
@@ -1431,7 +1495,7 @@
     "node_modules/check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -1508,7 +1572,7 @@
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -1540,13 +1604,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "node_modules/colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -1564,23 +1622,20 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1589,15 +1644,14 @@
       "dev": true
     },
     "node_modules/cron-parser": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
-      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
+      "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
       "dependencies": {
-        "is-nan": "^1.3.2",
-        "luxon": "^1.26.0"
+        "luxon": "^3.2.1"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/cross-env": {
@@ -1635,15 +1689,15 @@
     "node_modules/crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1660,51 +1714,59 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "node_modules/default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "dev": true,
       "dependencies": {
         "strip-bom": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -1738,9 +1800,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.35",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
-      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
+      "version": "0.37.20",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
+      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
     },
     "node_modules/discord.js": {
       "version": "14.7.1",
@@ -1773,15 +1835,14 @@
       }
     },
     "node_modules/discordx": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/discordx/-/discordx-10.0.0.tgz",
-      "integrity": "sha512-RPjegdLE/w7uRr4brAdhqRMfMsu8458HIOoFrt04QOdLDlTqWzQBlxV1qxQ3WsC3o4jEt5jkJaMdMYXIvcBSrQ==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/discordx/-/discordx-11.7.1.tgz",
+      "integrity": "sha512-hFjKz5D4e87c4Hojs9wvAc3KgbC/j2QC/SF3YXAJDqzLVwjWkWJnJAutNJjmUTHjY/lJKsFlUd5Gu6NjXlUsPw==",
       "dependencies": {
-        "@discordx/di": "^2.0.1",
+        "@discordx/di": "^3.0.3",
         "@discordx/internal": "^1.0.2",
         "lodash": "^4.17.21",
-        "reflect-metadata": "^0.1.13",
-        "tslib": "^2.4.0"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -1812,9 +1873,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.801",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.801.tgz",
-      "integrity": "sha512-xapG8ekC+IAHtJrGBMQSImNuN+dm+zl7UP1YbhvTkwQn8zf/yYuoxfTSAEiJ9VDD+kjvXaAhNDPSxJ+VImtAJA==",
+      "version": "1.4.320",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.320.tgz",
+      "integrity": "sha512-h70iRscrNluMZPVICXYl5SSB+rBKo22XfuIS1ER0OQxQZpKTnFpuS6coj7wY9M/3trv7OR88rRMOlKmRvDty7Q==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1824,28 +1885,44 @@
       "dev": true
     },
     "node_modules/es-abstract": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
       "dev": true,
       "dependencies": {
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
-        "object-inspect": "^1.11.0",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1855,14 +1932,14 @@
       }
     },
     "node_modules/es-abstract/node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -1870,6 +1947,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
@@ -1907,7 +2004,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -1987,24 +2084,21 @@
       }
     },
     "node_modules/eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
+        "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/eslint-visitor-keys": {
@@ -2041,6 +2135,18 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/eslint/node_modules/eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -2050,10 +2156,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/eslint/node_modules/path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -2080,7 +2195,7 @@
     "node_modules/eslint/node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -2092,7 +2207,7 @@
     "node_modules/eslint/node_modules/shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2147,9 +2262,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -2159,9 +2274,9 @@
       }
     },
     "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -2180,9 +2295,9 @@
       }
     },
     "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -2226,9 +2341,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2238,7 +2353,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2250,13 +2365,13 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2318,9 +2433,9 @@
       }
     },
     "node_modules/find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
@@ -2402,9 +2517,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -2418,6 +2533,15 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
       }
     },
     "node_modules/foreground-child": {
@@ -2470,7 +2594,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -2491,13 +2615,41 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -2520,20 +2672,21 @@
     "node_modules/get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2546,6 +2699,22 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -2592,17 +2761,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -2612,19 +2796,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globby/node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
       "dev": true,
-      "engines": {
-        "node": ">= 4"
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "node_modules/growl": {
@@ -2640,6 +2827,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -2648,9 +2836,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2659,16 +2847,41 @@
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
         "node": ">=4"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2754,9 +2967,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -2765,7 +2978,7 @@
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
     "node_modules/import-fresh": {
@@ -2787,7 +3000,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -2805,7 +3018,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -2909,12 +3122,12 @@
       }
     },
     "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -2933,12 +3146,12 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -2946,11 +3159,28 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/is-bigint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.3.tgz",
-      "integrity": "sha512-ZU538ajmYJmzysE5yU4Y7uIrPQ2j704u+hXFiIPQExpqzzUbpe5jCPdTfmz7jXRxZdvjY3KZ3ZNenoXQovX+Dg==",
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2989,9 +3219,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3018,7 +3248,7 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3034,9 +3264,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3045,25 +3275,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -3082,9 +3297,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -3107,6 +3322,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3154,11 +3381,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -3172,19 +3430,19 @@
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3227,18 +3485,17 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -3295,9 +3552,9 @@
       }
     },
     "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -3305,22 +3562,13 @@
         "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -3370,7 +3618,7 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "node_modules/json5": {
@@ -3394,7 +3642,7 @@
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -3425,13 +3673,13 @@
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.snakecase": {
@@ -3454,26 +3702,32 @@
     "node_modules/long-timeout": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
       "engines": {
-        "node": "*"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -3526,13 +3780,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -3569,9 +3823,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3581,18 +3835,21 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -3664,6 +3921,30 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mocha/node_modules/ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -3673,7 +3954,7 @@
     "node_modules/mocha/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3718,7 +3999,7 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/nice-try": {
@@ -3792,17 +4073,17 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
     "node_modules/node-schedule": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.0.tgz",
-      "integrity": "sha512-nl4JTiZ7ZQDc97MmpTq9BQjYhq7gOtoh7SiPH069gBFBj0PzD8HI7zyFs6rzqL8Y5tTiEEYLxgtbx034YPrbyQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
       "dependencies": {
-        "cron-parser": "^3.5.0",
+        "cron-parser": "^4.2.0",
         "long-timeout": "0.1.1",
         "sorted-array-functions": "^1.3.0"
       },
@@ -3811,9 +4092,9 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.21.tgz",
+      "integrity": "sha512-djN/n2549DUtY33S7o1djRCd7dEm0kBnj9c7S9XVXqRUbuggN1MZH/Nqa+5RFQr63Fbefq37nFXAE9VU86yL1A==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",
@@ -3888,18 +4169,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/nodemon/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3924,7 +4193,7 @@
     "node_modules/nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
       "dev": true,
       "dependencies": {
         "abbrev": "1"
@@ -4053,15 +4322,15 @@
       }
     },
     "node_modules/nyc/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -4130,12 +4399,12 @@
       }
     },
     "node_modules/nyc/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -4191,9 +4460,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4203,6 +4472,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4223,14 +4493,15 @@
       }
     },
     "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
-      "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
+      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
       "dev": true,
       "dependencies": {
+        "array.prototype.reduce": "^1.0.5",
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "engines": {
         "node": ">= 0.8"
@@ -4242,7 +4513,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -4283,7 +4554,7 @@
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4367,7 +4638,7 @@
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -4376,7 +4647,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4430,10 +4701,16 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -4503,7 +4780,7 @@
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -4537,9 +4814,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4610,6 +4887,23 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4625,7 +4919,7 @@
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "dependencies": {
         "es6-error": "^4.0.1"
@@ -4637,7 +4931,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4744,10 +5038,37 @@
       "dev": true
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4756,9 +5077,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4770,10 +5091,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/shebang-command": {
@@ -4812,15 +5151,15 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/simple-update-notifier": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
-      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
+      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
       "dev": true,
       "dependencies": {
         "semver": "~7.0.0"
@@ -4912,7 +5251,7 @@
     "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -4924,31 +5263,22 @@
       "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spawn-wrap": {
@@ -4986,7 +5316,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/streamsearch": {
@@ -5005,34 +5335,15 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -5048,38 +5359,40 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5170,7 +5483,7 @@
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5205,15 +5518,15 @@
       }
     },
     "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -5227,13 +5540,13 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/tmp": {
@@ -5251,7 +5564,7 @@
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5354,7 +5667,7 @@
     "node_modules/ts-mocha/node_modules/yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5396,21 +5709,35 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "json5": "^2.2.0",
-        "minimist": "^1.2.0",
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -5444,9 +5771,9 @@
       "dev": true
     },
     "node_modules/tsyringe": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
-      "integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.7.0.tgz",
+      "integrity": "sha512-ncFDM1jTLsok4ejMvSW5jN1VGPQD48y2tfAR0pdptWRKYX4bkbqPt92k7KJ5RFJ1KV36JEs/+TMh7I6OUgj74g==",
       "dependencies": {
         "tslib": "^1.9.3"
       },
@@ -5462,7 +5789,7 @@
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -5489,6 +5816,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -5504,9 +5845,9 @@
       "integrity": "sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w=="
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5517,14 +5858,14 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -5548,6 +5889,32 @@
         "node": ">=12.18"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5563,13 +5930,12 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -5628,8 +5994,28 @@
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -5652,7 +6038,7 @@
     "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5674,7 +6060,7 @@
     "node_modules/wide-align/node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -5715,7 +6101,7 @@
     "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5738,7 +6124,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write": {
@@ -5792,9 +6178,9 @@
       "dev": true
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "node_modules/yargs": {
@@ -5848,7 +6234,7 @@
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5879,72 +6265,51 @@
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+    "@ampproject/remapping": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.14.5"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
-      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
+      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
+      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.21.0",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.0",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/generator": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.15.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      }
-    },
-    "@babel/helper-compilation-targets": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-      "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.15.0",
-        "@babel/helper-validator-option": "^7.14.5",
-        "browserslist": "^4.16.6",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -5956,172 +6321,191 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+    "@babel/generator": {
+      "version": "7.21.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
+      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.21.0",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
       }
     },
-    "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+    "@babel/helper-compilation-targets": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
+    },
+    "@babel/helper-function-name": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
+      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-      "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.15.0"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-      "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-      "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
+      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.14.5",
-        "@babel/helper-replace-supers": "^7.15.0",
-        "@babel/helper-simple-access": "^7.14.8",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-      "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.14.5"
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-      "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.15.0",
-        "@babel/helper-optimise-call-expression": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-      "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.8"
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.18.6"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "dev": true
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.14.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
-      "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
+      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.8",
-        "@babel/types": "^7.14.8"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
-      "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
+      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
+      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.21.1",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.21.2",
+        "@babel/types": "^7.21.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -6135,12 +6519,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "version": "7.21.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
+      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -6156,7 +6541,7 @@
       "requires": {
         "@discordjs/util": "^0.1.0",
         "@sapphire/shapeshift": "^3.7.1",
-        "discord-api-types": "^0.37.20",
+        "discord-api-types": "0.37.20",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.2",
         "tslib": "^2.4.1"
@@ -6176,7 +6561,7 @@
         "@discordjs/util": "^0.1.0",
         "@sapphire/async-queue": "^1.5.0",
         "@sapphire/snowflake": "^3.2.2",
-        "discord-api-types": "^0.37.23",
+        "discord-api-types": "0.37.20",
         "file-type": "^18.0.0",
         "tslib": "^2.4.1",
         "undici": "^5.13.0"
@@ -6188,11 +6573,11 @@
       "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
     },
     "@discordx/di": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@discordx/di/-/di-2.0.1.tgz",
-      "integrity": "sha512-aIGd97QJwdMkpANcaErYj0iv25loKdJQulUB1+a83Z3Jm+YVBFI7MHSad5zjdg4GYpGsOV1JW+xHhAwW21IhoA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@discordx/di/-/di-3.0.3.tgz",
+      "integrity": "sha512-aLjThqw6/FJNxHrDXFwiWUnbN5MKnt2Ef99Ry6sH4SiIqbM1MRCSM4nsPxnTuR5+noM9hKD6nYSoNaAGjaMcYQ==",
       "requires": {
-        "tsyringe": "^4.6.0",
+        "tsyringe": "^4.7.0",
         "typedi": "^0.10.0"
       }
     },
@@ -6260,9 +6645,9 @@
       }
     },
     "@istanbuljs/nyc-config-typescript": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
-      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz",
+      "integrity": "sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==",
       "dev": true,
       "requires": {
         "@istanbuljs/schema": "^0.1.2"
@@ -6273,6 +6658,44 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
     },
     "@lambocreeper/mock-discord.js": {
       "version": "2.0.1",
@@ -6290,18 +6713,10 @@
           "dev": true,
           "requires": {
             "@sapphire/shapeshift": "^3.5.1",
-            "discord-api-types": "^0.36.2",
+            "discord-api-types": "0.37.20",
             "fast-deep-equal": "^3.1.3",
             "ts-mixer": "^6.0.1",
             "tslib": "^2.4.0"
-          },
-          "dependencies": {
-            "discord-api-types": {
-              "version": "0.36.3",
-              "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-              "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==",
-              "dev": true
-            }
           }
         },
         "@discordjs/collection": {
@@ -6319,12 +6734,6 @@
             "@types/node": "*"
           }
         },
-        "discord-api-types": {
-          "version": "0.33.5",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-          "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg==",
-          "dev": true
-        },
         "discord.js": {
           "version": "13.13.1",
           "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.13.1.tgz",
@@ -6336,7 +6745,7 @@
             "@sapphire/async-queue": "^1.5.0",
             "@types/node-fetch": "^2.6.2",
             "@types/ws": "^8.5.3",
-            "discord-api-types": "^0.33.5",
+            "discord-api-types": "0.37.20",
             "form-data": "^4.0.0",
             "node-fetch": "^2.6.7",
             "ws": "^8.9.0"
@@ -6390,9 +6799,9 @@
       "integrity": "sha512-zZxymtVO6zeXVMPds+6d7gv/OfnCc25M1Z+7ZLB0oPmeMTPeRWVPQSS16oDJy5ZsyCOLj7M6mbZml5gWXcVRNw=="
     },
     "@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
+      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -6419,9 +6828,9 @@
       }
     },
     "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@tokenizer/token": {
@@ -6430,22 +6839,29 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@types/assert": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.5.tgz",
-      "integrity": "sha512-myz5KWf6ox66Ou1m0KiLZpitk7W6Vly2LFRx7AXHSLeMUM6bmDIStIBk0xd7I2vXcAQEuhegdpjPuypmP5ui0Q==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.6.tgz",
+      "integrity": "sha512-Y7gDJiIqb9qKUHfBQYOWGngUpLORtirAVPuj/CWJrU2C6ZM4/y3XLwuwfGMF8s7QzW746LQZx23m0+1FSgjfug==",
       "dev": true
     },
     "@types/chai": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
-      "integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "optional": true
     },
     "@types/mocha": {
       "version": "7.0.2",
@@ -6454,9 +6870,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
-      "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -6500,9 +6916,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-      "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
     },
     "@types/ws": {
@@ -6515,83 +6931,71 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz",
-      "integrity": "sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.29.1",
-        "@typescript-eslint/scope-manager": "4.29.1",
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
         "regexpp": "^3.1.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "4.29.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz",
-          "integrity": "sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.7",
-            "@typescript-eslint/scope-manager": "4.29.1",
-            "@typescript-eslint/types": "4.29.1",
-            "@typescript-eslint/typescript-estree": "4.29.1",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          },
-          "dependencies": {
-            "eslint-utils": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-              "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-              "dev": true,
-              "requires": {
-                "eslint-visitor-keys": "^2.0.0"
-              }
-            }
-          }
-        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.7",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.1.tgz",
-      "integrity": "sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.29.1",
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/typescript-estree": "4.29.1",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz",
-      "integrity": "sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1"
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.1.tgz",
-      "integrity": "sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz",
-      "integrity": "sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
-        "@typescript-eslint/visitor-keys": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -6600,12 +7004,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz",
-      "integrity": "sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.29.1",
+        "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -6689,9 +7093,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -6710,7 +7114,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "arg": {
@@ -6734,10 +7138,23 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
     "assertion-error": {
@@ -6758,10 +7175,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
+    },
     "axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
         "follow-redirects": "^1.14.0"
       }
@@ -6813,16 +7236,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
-        "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       }
     },
     "buffer-from": {
@@ -6860,6 +7282,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -6878,21 +7301,22 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001460",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001460.tgz",
+      "integrity": "sha512-Bud7abqjvEjipUkpLs4D7gR0l8hBYBHoa+tGtKJHvT2AYzLp1z7EmVkUT4ERpVUfca8S2HGIVs883D8pUH1ZzQ==",
       "dev": true
     },
     "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
@@ -6917,12 +7341,12 @@
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
     },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
@@ -6982,7 +7406,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -7010,13 +7434,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colorette": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
-      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "combined-stream": {
@@ -7031,23 +7449,20 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "create-require": {
       "version": "1.1.1",
@@ -7056,12 +7471,11 @@
       "dev": true
     },
     "cron-parser": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-3.5.0.tgz",
-      "integrity": "sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
+      "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
       "requires": {
-        "is-nan": "^1.3.2",
-        "luxon": "^1.26.0"
+        "luxon": "^3.2.1"
       }
     },
     "cross-env": {
@@ -7087,12 +7501,12 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -7101,39 +7515,41 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "dev": true,
       "requires": {
         "strip-bom": "^4.0.0"
       }
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "delayed-stream": {
@@ -7158,9 +7574,9 @@
       }
     },
     "discord-api-types": {
-      "version": "0.37.35",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.35.tgz",
-      "integrity": "sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg=="
+      "version": "0.37.20",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.20.tgz",
+      "integrity": "sha512-uAO+55E11rMkYR36/paE1vKN8c2bZa1mgrIaiQIBgIZRKZTDIGOZB+8I5eMRPFJcGxrg16riUu+0aTu2JQEPew=="
     },
     "discord.js": {
       "version": "14.7.1",
@@ -7173,7 +7589,7 @@
         "@discordjs/util": "^0.1.0",
         "@sapphire/snowflake": "^3.2.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.20",
+        "discord-api-types": "0.37.20",
         "fast-deep-equal": "^3.1.3",
         "lodash.snakecase": "^4.1.1",
         "tslib": "^2.4.1",
@@ -7192,15 +7608,14 @@
       }
     },
     "discordx": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/discordx/-/discordx-10.0.0.tgz",
-      "integrity": "sha512-RPjegdLE/w7uRr4brAdhqRMfMsu8458HIOoFrt04QOdLDlTqWzQBlxV1qxQ3WsC3o4jEt5jkJaMdMYXIvcBSrQ==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/discordx/-/discordx-11.7.1.tgz",
+      "integrity": "sha512-hFjKz5D4e87c4Hojs9wvAc3KgbC/j2QC/SF3YXAJDqzLVwjWkWJnJAutNJjmUTHjY/lJKsFlUd5Gu6NjXlUsPw==",
       "requires": {
-        "@discordx/di": "^2.0.1",
+        "@discordx/di": "^3.0.3",
         "@discordx/internal": "^1.0.2",
         "lodash": "^4.17.21",
-        "reflect-metadata": "^0.1.13",
-        "tslib": "^2.4.0"
+        "tslib": "^2.5.0"
       }
     },
     "doctrine": {
@@ -7218,9 +7633,9 @@
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
     },
     "electron-to-chromium": {
-      "version": "1.3.801",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.801.tgz",
-      "integrity": "sha512-xapG8ekC+IAHtJrGBMQSImNuN+dm+zl7UP1YbhvTkwQn8zf/yYuoxfTSAEiJ9VDD+kjvXaAhNDPSxJ+VImtAJA==",
+      "version": "1.4.320",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.320.tgz",
+      "integrity": "sha512-h70iRscrNluMZPVICXYl5SSB+rBKo22XfuIS1ER0OQxQZpKTnFpuS6coj7wY9M/3trv7OR88rRMOlKmRvDty7Q==",
       "dev": true
     },
     "emoji-regex": {
@@ -7230,42 +7645,75 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-      "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
       "dev": true,
       "requires": {
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.3",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
-        "object-inspect": "^1.11.0",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "dependencies": {
         "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
           "dev": true,
           "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "has-symbols": "^1.0.3",
             "object-keys": "^1.1.1"
           }
         }
+      }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "es-to-primitive": {
@@ -7294,7 +7742,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "eslint": {
@@ -7363,16 +7811,31 @@
             }
           }
         },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
         "path-key": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
           "dev": true
         },
         "regexpp": {
@@ -7390,7 +7853,7 @@
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -7399,7 +7862,7 @@
         "shebang-regex": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true
         },
         "which": {
@@ -7430,20 +7893,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "eslint-visitor-keys": {
@@ -7478,18 +7933,18 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -7504,9 +7959,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }
@@ -7540,9 +7995,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7561,13 +8016,13 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -7611,9 +8066,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -7665,9 +8120,18 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -7699,7 +8163,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -7712,12 +8176,31 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
     "gensync": {
@@ -7735,17 +8218,18 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-package-type": {
@@ -7753,6 +8237,16 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "glob": {
       "version": "7.1.3",
@@ -7786,32 +8280,42 @@
         "type-fest": "^0.8.1"
       }
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
       "dev": true
     },
     "growl": {
@@ -7824,26 +8328,43 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -7891,15 +8412,15 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
     "import-fresh": {
@@ -7915,7 +8436,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -7927,7 +8448,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -8007,12 +8528,12 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -8027,21 +8548,35 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
     },
+    "is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "is-bigint": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.3.tgz",
-      "integrity": "sha512-ZU538ajmYJmzysE5yU4Y7uIrPQ2j704u+hXFiIPQExpqzzUbpe5jCPdTfmz7jXRxZdvjY3KZ3ZNenoXQovX+Dg==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -8068,9 +8603,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true
     },
     "is-date-object": {
@@ -8085,7 +8620,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -8095,27 +8630,18 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
     },
-    "is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      }
-    },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true
     },
     "is-number": {
@@ -8125,9 +8651,9 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -8141,6 +8667,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
       }
     },
     "is-stream": {
@@ -8167,11 +8702,33 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -8182,19 +8739,19 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
-      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -8227,18 +8784,17 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "rimraf": {
@@ -8281,28 +8837,20 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
-      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -8340,7 +8888,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
@@ -8358,7 +8906,7 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
@@ -8383,13 +8931,13 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.snakecase": {
@@ -8409,21 +8957,30 @@
     "long-timeout": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
-      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
+      "integrity": "sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w=="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "requires": {
-        "yallist": "^4.0.0"
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
       }
     },
     "luxon": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
-      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
     },
     "make-dir": {
       "version": "3.1.0",
@@ -8465,13 +9022,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime-db": {
@@ -8496,27 +9053,27 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       }
     },
     "mocha": {
@@ -8570,6 +9127,24 @@
             "esprima": "^4.0.0"
           }
         },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -8579,7 +9154,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
           "dev": true
         },
         "supports-color": {
@@ -8617,7 +9192,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "nice-try": {
@@ -8676,25 +9251,25 @@
       }
     },
     "node-releases": {
-      "version": "1.1.73",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-      "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
     "node-schedule": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.0.tgz",
-      "integrity": "sha512-nl4JTiZ7ZQDc97MmpTq9BQjYhq7gOtoh7SiPH069gBFBj0PzD8HI7zyFs6rzqL8Y5tTiEEYLxgtbx034YPrbyQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-2.1.1.tgz",
+      "integrity": "sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==",
       "requires": {
-        "cron-parser": "^3.5.0",
+        "cron-parser": "^4.2.0",
         "long-timeout": "0.1.1",
         "sorted-array-functions": "^1.3.0"
       }
     },
     "nodemon": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
-      "integrity": "sha512-Km2mWHKKY5GzRg6i1j5OxOHQtuvVsgskLfigG25yTtbyfRGn/GNvIbRyOf1PSCKJ2aT/58TiuUsuOU5UToVViw==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.21.tgz",
+      "integrity": "sha512-djN/n2549DUtY33S7o1djRCd7dEm0kBnj9c7S9XVXqRUbuggN1MZH/Nqa+5RFQr63Fbefq37nFXAE9VU86yL1A==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.2",
@@ -8741,15 +9316,6 @@
           "dev": true,
           "optional": true
         },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
         "readdirp": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -8770,7 +9336,7 @@
     "nopt": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
       "dev": true,
       "requires": {
         "abbrev": "1"
@@ -8869,15 +9435,15 @@
           }
         },
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -8922,12 +9488,12 @@
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
@@ -8973,15 +9539,16 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
@@ -8996,20 +9563,21 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
-      "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.5.tgz",
+      "integrity": "sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==",
       "dev": true,
       "requires": {
+        "array.prototype.reduce": "^1.0.5",
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -9041,7 +9609,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
     "p-limit": {
@@ -9101,13 +9669,13 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -9142,10 +9710,16 @@
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
       "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A=="
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pkg-dir": {
@@ -9196,7 +9770,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true
     },
     "process-on-spawn": {
@@ -9221,9 +9795,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "queue-microtask": {
@@ -9264,6 +9838,17 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -9273,7 +9858,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -9282,7 +9867,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-main-filename": {
@@ -9355,10 +9940,20 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -9367,18 +9962,35 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "shebang-command": {
@@ -9408,15 +10020,15 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "simple-update-notifier": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
-      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
+      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
       "dev": true,
       "requires": {
         "semver": "~7.0.0"
@@ -9487,7 +10099,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         }
       }
@@ -9498,27 +10110,19 @@
       "integrity": "sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA=="
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "spawn-wrap": {
@@ -9549,7 +10153,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "streamsearch": {
@@ -9563,24 +10167,17 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
       }
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9590,34 +10187,36 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "strip-ansi": {
@@ -9680,7 +10279,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -9708,15 +10307,15 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
@@ -9726,13 +10325,13 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "tmp": {
@@ -9747,7 +10346,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -9817,7 +10416,7 @@
         "yn": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+          "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
           "dev": true
         }
       }
@@ -9845,21 +10444,32 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
-      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "json5": "^2.2.0",
-        "minimist": "^1.2.0",
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
+        "json5": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true,
           "optional": true
         }
@@ -9888,9 +10498,9 @@
       }
     },
     "tsyringe": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.6.0.tgz",
-      "integrity": "sha512-BMQAZamSfEmIQzH8WJeRu1yZGQbPSDuI9g+yEiKZFIcO46GPZuMOC2d0b52cVBdw1d++06JnDSIIZvEnogMdAw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.7.0.tgz",
+      "integrity": "sha512-ncFDM1jTLsok4ejMvSW5jN1VGPQD48y2tfAR0pdptWRKYX4bkbqPt92k7KJ5RFJ1KV36JEs/+TMh7I6OUgj74g==",
       "requires": {
         "tslib": "^1.9.3"
       },
@@ -9905,7 +10515,7 @@
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
@@ -9923,6 +10533,17 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -9938,20 +10559,20 @@
       "integrity": "sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w=="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -9969,6 +10590,16 @@
         "busboy": "^1.6.0"
       }
     },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9984,9 +10615,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -10036,8 +10667,22 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      }
     },
     "wide-align": {
       "version": "1.1.3",
@@ -10057,7 +10702,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -10073,7 +10718,7 @@
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -10107,7 +10752,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -10126,7 +10771,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write": {
@@ -10163,9 +10808,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {
@@ -10195,7 +10840,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@codesupport/inherited-config": "^1.0.2",
     "axios": "^0.21.2",
     "axios-cache-adapter": "^2.5.0",
-    "discord.js": "^13.9.0",
-    "discordx": "^9.9.0",
+    "discord.js": "^14.0.3",
+    "discordx": "^10.0.0",
     "dotenv": "^8.2.0",
     "node-schedule": "^2.1.0",
     "reflect-metadata": "^0.1.13"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/assert": "^1.5.2",
     "@types/chai": "^4.2.14",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^17.0.8",
+    "@types/node": "^18.14.6",
     "@types/node-schedule": "^1.3.2",
     "@types/sinon": "^9.0.8",
     "@types/ws": "^7.4.0",
@@ -66,7 +66,7 @@
     "nyc": "^15.1.0",
     "sinon": "^9.2.1",
     "ts-mocha": "^7.0.0",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.5.4"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,18 +29,21 @@
   "homepage": "https://github.com/codesupport/discord-bot#readme",
   "type": "commonjs",
   "engines": {
-    "node": ">=16.6.0",
+    "node": ">=16.9.0",
     "npm": ">=7.0.0"
   },
   "dependencies": {
     "@codesupport/inherited-config": "^1.0.2",
     "axios": "^0.21.2",
     "axios-cache-adapter": "^2.5.0",
-    "discord.js": "^14.0.3",
-    "discordx": "^10.0.0",
+    "discord.js": "^14.7.1",
+    "discordx": "^11.7.1",
     "dotenv": "^8.2.0",
     "node-schedule": "^2.1.0",
     "reflect-metadata": "^0.1.13"
+  },
+  "overrides": {
+    "discord-api-types": "0.37.20"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@codesupport/inherited-config": "^1.0.2",
     "axios": "^0.21.2",
     "axios-cache-adapter": "^2.5.0",
-    "discord.js": "^13.5.0",
-    "discordx": "^9.1.7",
+    "discord.js": "^13.9.0",
+    "discordx": "^9.9.0",
     "dotenv": "^8.2.0",
     "node-schedule": "^2.1.0",
     "reflect-metadata": "^0.1.13"

--- a/package.json
+++ b/package.json
@@ -36,18 +36,15 @@
     "@codesupport/inherited-config": "^1.0.2",
     "axios": "^0.21.2",
     "axios-cache-adapter": "^2.5.0",
-    "discord.js": "^14.7.1",
+    "discord.js": "^14.8.0",
     "discordx": "^11.7.1",
     "dotenv": "^8.2.0",
     "node-schedule": "^2.1.0",
     "reflect-metadata": "^0.1.13"
   },
-  "overrides": {
-    "discord-api-types": "0.37.20"
-  },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@lambocreeper/mock-discord.js": "^2.0.1",
+    "@lambocreeper/mock-discord.js": "^3.0.0",
     "@types/assert": "^1.5.2",
     "@types/chai": "^4.2.14",
     "@types/mocha": "^7.0.2",

--- a/src/abstracts/LogMessageDeleteHandler.ts
+++ b/src/abstracts/LogMessageDeleteHandler.ts
@@ -1,4 +1,4 @@
-import {MessageEmbed, Message, TextChannel, ColorResolvable} from "discord.js";
+import {EmbedBuilder, Message, TextChannel, ColorResolvable} from "discord.js";
 import EventHandler from "./EventHandler";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -6,11 +6,11 @@ import GenericObject from "../interfaces/GenericObject";
 abstract class LogMessageDeleteHandler extends EventHandler {
 	async sendLog(message: Message): Promise<void> {
 		if (message.content !== "") {
-			const embed = new MessageEmbed();
+			const embed = new EmbedBuilder();
 
 			embed.setTitle("Message Deleted");
 			embed.setDescription(`Author: ${message.author}\nChannel: ${message.channel}`);
-			embed.addField("Message", message.content);
+			embed.addFields([{ name: "Message", value: message.content }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 
 			const logsChannel = message.guild?.channels.cache.find(

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,8 @@ class App {
 		this.client = new Client({
 			botId: getConfigValue<string>("BOT_ID"),
 			botGuilds: [getConfigValue<string>("GUILD_ID")],
-			intents: DiscordUtils.getAllIntentsApartFromPresence()
+			intents: DiscordUtils.getAllIntentsApartFromPresence(),
+			silent: false
 		});
 	}
 
@@ -36,7 +37,7 @@ class App {
 
 	async init(): Promise<void> {
 		this.client.once("ready", async () => {
-			await this.client.initApplicationCommands({ guild: { log: true }});
+			await this.client.initApplicationCommands();
 		});
 
 		await DirectoryUtils.getFilesInDirectory(

--- a/src/app.ts
+++ b/src/app.ts
@@ -37,7 +37,6 @@ class App {
 	async init(): Promise<void> {
 		this.client.once("ready", async () => {
 			await this.client.initApplicationCommands({ guild: { log: true }});
-			await this.client.initApplicationPermissions();
 		});
 
 		await DirectoryUtils.getFilesInDirectory(

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -9,9 +9,9 @@ import {Discord, Slash, SlashOption} from "discordx";
 class AdventOfCodeCommand {
 	@Slash({ name: "aoc", description: "Advent Of Code" })
 	async onInteract(
-		interaction: CommandInteraction,
-		@SlashOption({ name: "year", description: "AOC year", type: ApplicationCommandOptionType.Number, minValue: 2015, required: false }) year?: number,
-		@SlashOption({ name: "name", description: "User's name", type: ApplicationCommandOptionType.String, required: false }) name?: string,
+		@SlashOption({ name: "year", description: "AOC year", type: ApplicationCommandOptionType.Number, minValue: 2015, required: false }) year: number | undefined,
+		@SlashOption({ name: "name", description: "User's name", type: ApplicationCommandOptionType.String, required: false }) name: string | undefined,
+		interaction: CommandInteraction
 	): Promise<void> {
 		const adventOfCodeService = AdventOfCodeService.getInstance();
 		const embed = new EmbedBuilder();

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, EmbedBuilder, CommandInteraction, ButtonStyle, MessageActionRow, ButtonBuilder } from "discord.js";
+import { ColorResolvable, EmbedBuilder, CommandInteraction, ButtonStyle, MessageActionRow, ButtonBuilder, ApplicationCommandOptionType } from "discord.js";
 import AdventOfCodeService from "../services/AdventOfCodeService";
 import { AOCMember } from "../interfaces/AdventOfCode";
 import getConfigValue from "../utils/getConfigValue";
@@ -9,8 +9,8 @@ import {Discord, Slash, SlashOption} from "discordx";
 class AdventOfCodeCommand {
 	@Slash("aoc", {description: "Advent Of Code"})
 	async onInteract(
-		@SlashOption("year", {type: "NUMBER", minValue: 2015, required: false}) year: number,
-		@SlashOption("name", {type: "STRING", required: false}) name: string,
+		@SlashOption("year", {type: ApplicationCommandOptionType.Number, minValue: 2015, required: false}) year: number,
+		@SlashOption("name", {type: ApplicationCommandOptionType.String, required: false}) name: string,
 			interaction: CommandInteraction): Promise<void> {
 		const adventOfCodeService = AdventOfCodeService.getInstance();
 		const embed = new EmbedBuilder();

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, EmbedBuilder, CommandInteraction, Constants, MessageActionRow, MessageButton } from "discord.js";
+import { ColorResolvable, EmbedBuilder, CommandInteraction, ButtonStyle, MessageActionRow, ButtonBuilder } from "discord.js";
 import AdventOfCodeService from "../services/AdventOfCodeService";
 import { AOCMember } from "../interfaces/AdventOfCode";
 import getConfigValue from "../utils/getConfigValue";
@@ -14,7 +14,7 @@ class AdventOfCodeCommand {
 			interaction: CommandInteraction): Promise<void> {
 		const adventOfCodeService = AdventOfCodeService.getInstance();
 		const embed = new EmbedBuilder();
-		const button = new MessageButton();
+		const button = new ButtonBuilder();
 		let yearToQuery = this.getYear();
 
 		if (!!year && year <= yearToQuery) {
@@ -29,7 +29,7 @@ class AdventOfCodeCommand {
 		const description = `Invite Code: \`${getConfigValue<string>("ADVENT_OF_CODE_INVITE")}\``;
 
 		button.setLabel(buttonLabel);
-		button.setStyle(Constants.MessageButtonStyles.LINK);
+		button.setStyle(ButtonStyle.Link);
 		button.setURL(link);
 
 		const row = new MessageActionRow().addComponents(button);

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, EmbedBuilder, CommandInteraction, ButtonStyle, MessageActionRow, ButtonBuilder, ApplicationCommandOptionType } from "discord.js";
+import { ColorResolvable, EmbedBuilder, CommandInteraction, ButtonStyle, ActionRowBuilder, ButtonBuilder, ApplicationCommandOptionType } from "discord.js";
 import AdventOfCodeService from "../services/AdventOfCodeService";
 import { AOCMember } from "../interfaces/AdventOfCode";
 import getConfigValue from "../utils/getConfigValue";
@@ -32,7 +32,7 @@ class AdventOfCodeCommand {
 		button.setStyle(ButtonStyle.Link);
 		button.setURL(link);
 
-		const row = new MessageActionRow().addComponents(button);
+		const row = new ActionRowBuilder().addComponents(button);
 
 		if (!!name) {
 			try {

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, MessageEmbed, CommandInteraction, Constants, MessageActionRow, MessageButton } from "discord.js";
+import { ColorResolvable, EmbedBuilder, CommandInteraction, Constants, MessageActionRow, MessageButton } from "discord.js";
 import AdventOfCodeService from "../services/AdventOfCodeService";
 import { AOCMember } from "../interfaces/AdventOfCode";
 import getConfigValue from "../utils/getConfigValue";
@@ -13,7 +13,7 @@ class AdventOfCodeCommand {
 		@SlashOption("name", {type: "STRING", required: false}) name: string,
 			interaction: CommandInteraction): Promise<void> {
 		const adventOfCodeService = AdventOfCodeService.getInstance();
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 		const button = new MessageButton();
 		let yearToQuery = this.getYear();
 
@@ -45,10 +45,12 @@ class AdventOfCodeCommand {
 
 				embed.setTitle("Advent Of Code");
 				embed.setDescription(description);
-				embed.addField(`Scores of ${user.name} in ${yearToQuery}`, "\u200B");
-				embed.addField("Position", position.toString(), true);
-				embed.addField("Stars", user.stars.toString(), true);
-				embed.addField("Points", user.local_score.toString(), true);
+				embed.addFields([
+					{ name: `Scores of ${user.name} in ${yearToQuery}`, value: "\u200B"},
+					{ name: "Position", value: position.toString(), inline: true },
+					{ name: "Stars", value: user.stars.toString(), inline: true },
+					{ name: "Points", value: user.local_score.toString(), inline: true }
+				]);
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 
 				await interaction.reply({embeds: [embed], components: [row]});
@@ -65,7 +67,7 @@ class AdventOfCodeCommand {
 
 			embed.setTitle("Advent Of Code");
 			embed.setDescription(description);
-			embed.addField(`Top ${getConfigValue<number>("ADVENT_OF_CODE_RESULTS_PER_PAGE")} in ${yearToQuery}`, playerList);
+			embed.addFields([{ name: `Top ${getConfigValue<number>("ADVENT_OF_CODE_RESULTS_PER_PAGE")} in ${yearToQuery}`, value: playerList }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 		} catch {
 			await interaction.reply({embeds: [this.errorEmbed("Could not get the leaderboard for Advent Of Code.")], ephemeral: true});
@@ -127,8 +129,8 @@ class AdventOfCodeCommand {
 		return list.concat("```");
 	}
 
-	private errorEmbed(description: string): MessageEmbed {
-		const embed = new MessageEmbed();
+	private errorEmbed(description: string): EmbedBuilder {
+		const embed = new EmbedBuilder();
 
 		embed.setTitle("Error");
 		embed.setDescription(description);

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -7,11 +7,12 @@ import {Discord, Slash, SlashOption} from "discordx";
 
 @Discord()
 class AdventOfCodeCommand {
-	@Slash("aoc", {description: "Advent Of Code"})
+	@Slash({ name: "aoc", description: "Advent Of Code" })
 	async onInteract(
-		@SlashOption("year", {type: ApplicationCommandOptionType.Number, minValue: 2015, required: false}) year: number,
-		@SlashOption("name", {type: ApplicationCommandOptionType.String, required: false}) name: string,
-			interaction: CommandInteraction): Promise<void> {
+		interaction: CommandInteraction,
+		@SlashOption({ name: "year", description: "AOC year", type: ApplicationCommandOptionType.Number, minValue: 2015, required: false }) year?: number,
+		@SlashOption({ name: "name", description: "User's name", type: ApplicationCommandOptionType.String, required: false }) name?: string,
+	): Promise<void> {
 		const adventOfCodeService = AdventOfCodeService.getInstance();
 		const embed = new EmbedBuilder();
 		const button = new ButtonBuilder();

--- a/src/commands/AdventOfCodeCommand.ts
+++ b/src/commands/AdventOfCodeCommand.ts
@@ -33,7 +33,7 @@ class AdventOfCodeCommand {
 		button.setStyle(ButtonStyle.Link);
 		button.setURL(link);
 
-		const row = new ActionRowBuilder().addComponents(button);
+		const row = new ActionRowBuilder<ButtonBuilder>().addComponents(button);
 
 		if (!!name) {
 			try {
@@ -54,7 +54,7 @@ class AdventOfCodeCommand {
 				]);
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 
-				await interaction.reply({embeds: [embed], components: [row]});
+				await interaction.reply({embeds: [embed], components: [row] });
 				return;
 			} catch {
 				await interaction.reply({embeds: [this.errorEmbed("Could not get the statistics for Advent Of Code.")], ephemeral: true});

--- a/src/commands/CodeblockCommand.ts
+++ b/src/commands/CodeblockCommand.ts
@@ -1,5 +1,5 @@
 import { Discord, Slash } from "discordx";
-import { EmbedBuilder, MessageAttachment, ColorResolvable, CommandInteraction} from "discord.js";
+import { EmbedBuilder, AttachmentBuilder, ColorResolvable, CommandInteraction} from "discord.js";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
 
@@ -8,7 +8,7 @@ class CodeblockCommand {
 	@Slash("codeblock")
 	async onInteract(interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
-		const image = new MessageAttachment("./assets/codeblock.png", "codeblock-tutorial.png");
+		const image = new AttachmentBuilder("./assets/codeblock.png", { name: "codeblock-tutorial.png" });
 
 		embed.setTitle("Codeblock Tutorial");
 		embed.setDescription("Please use codeblocks when sending code.");

--- a/src/commands/CodeblockCommand.ts
+++ b/src/commands/CodeblockCommand.ts
@@ -5,7 +5,7 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class CodeblockCommand {
-	@Slash("codeblock")
+	@Slash({ name: "codeblock", description: "Codeblock" })
 	async onInteract(interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 		const image = new AttachmentBuilder("./assets/codeblock.png", { name: "codeblock-tutorial.png" });

--- a/src/commands/CodeblockCommand.ts
+++ b/src/commands/CodeblockCommand.ts
@@ -1,5 +1,5 @@
 import { Discord, Slash } from "discordx";
-import { MessageEmbed, MessageAttachment, ColorResolvable, CommandInteraction} from "discord.js";
+import { EmbedBuilder, MessageAttachment, ColorResolvable, CommandInteraction} from "discord.js";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
 
@@ -7,12 +7,12 @@ import GenericObject from "../interfaces/GenericObject";
 class CodeblockCommand {
 	@Slash("codeblock")
 	async onInteract(interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 		const image = new MessageAttachment("./assets/codeblock.png", "codeblock-tutorial.png");
 
 		embed.setTitle("Codeblock Tutorial");
 		embed.setDescription("Please use codeblocks when sending code.");
-		embed.addField("Sending lots of code?", "Consider using a [GitHub Gist](http://gist.github.com).");
+		embed.addFields([{ name: "Sending lots of code?", value: "Consider using a [GitHub Gist](http://gist.github.com)." }]);
 		embed.setImage("attachment://codeblock-tutorial.png");
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 

--- a/src/commands/CodeblockCommand.ts
+++ b/src/commands/CodeblockCommand.ts
@@ -5,7 +5,7 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class CodeblockCommand {
-	@Slash({ name: "codeblock", description: "Codeblock" })
+	@Slash({ name: "codeblock", description: "Shows how to use a Discord codeblock" })
 	async onInteract(interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 		const image = new AttachmentBuilder("./assets/codeblock.png", { name: "codeblock-tutorial.png" });

--- a/src/commands/GitHubCommand.ts
+++ b/src/commands/GitHubCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
 import GitHubService from "../services/GitHubService";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -8,8 +8,8 @@ import {Discord, Slash, SlashOption} from "discordx";
 class GitHubCommand {
 	@Slash("github")
 	async onInteract(
-		@SlashOption("user", {type: "STRING"}) user: string,
-		@SlashOption("repository", {type: "STRING"}) repo: string,
+		@SlashOption("user", {type: ApplicationCommandOptionType.String}) user: string,
+		@SlashOption("repository", {type: ApplicationCommandOptionType.String}) repo: string,
 			interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 

--- a/src/commands/GitHubCommand.ts
+++ b/src/commands/GitHubCommand.ts
@@ -6,7 +6,7 @@ import {Discord, Slash, SlashOption} from "discordx";
 
 @Discord()
 class GitHubCommand {
-	@Slash({ name: "github", description: "Github info about a repository" })
+	@Slash({ name: "github", description: "Shows information about a GitHub repository" })
 	async onInteract(
 		@SlashOption({ name: "user", description: "Github user/account", type: ApplicationCommandOptionType.String, required: true }) user: string,
 		@SlashOption({ name: "repository", description: "Github repository", type: ApplicationCommandOptionType.String, required: true }) repo: string,

--- a/src/commands/GitHubCommand.ts
+++ b/src/commands/GitHubCommand.ts
@@ -6,11 +6,12 @@ import {Discord, Slash, SlashOption} from "discordx";
 
 @Discord()
 class GitHubCommand {
-	@Slash("github")
+	@Slash({ name: "github", description: "Github info about a repository" })
 	async onInteract(
-		@SlashOption("user", {type: ApplicationCommandOptionType.String}) user: string,
-		@SlashOption("repository", {type: ApplicationCommandOptionType.String}) repo: string,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashOption({ name: "user", description: "Github user/account", type: ApplicationCommandOptionType.String, required: true }) user: string,
+		@SlashOption({ name: "repository", description: "Github repository", type: ApplicationCommandOptionType.String, required: true }) repo: string,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const embed = new EmbedBuilder();
 
 		try {

--- a/src/commands/GitHubCommand.ts
+++ b/src/commands/GitHubCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import GitHubService from "../services/GitHubService";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -11,7 +11,7 @@ class GitHubCommand {
 		@SlashOption("user", {type: "STRING"}) user: string,
 		@SlashOption("repository", {type: "STRING"}) repo: string,
 			interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		try {
 			const GitHub = GitHubService.getInstance();
@@ -24,18 +24,20 @@ class GitHubCommand {
 
 			embed.setTitle(`GitHub Repository: ${res.user}/${res.repo}`);
 			embed.setDescription(desc);
-			embed.addField("Language", res.language, true);
-			embed.addField("Open issues", (res.issues_and_pullrequests_count - resPR.length).toString(), true);
-			embed.addField("Open Pull Requests", resPR.length.toString(), true);
-			embed.addField("Forks", res.forks.toString(), true);
-			embed.addField("Stars", res.stars.toString(), true);
-			embed.addField("Watchers", res.watchers.toString(), true);
+			embed.addFields([
+				{ name: "Language", value: res.language, inline: true },
+				{ name: "Open Issues", value: (res.issues_and_pullrequests_count - resPR.length).toString(), inline: true },
+				{ name: "Open Pull Requests", value: resPR.length.toString(), inline: true },
+				{ name: "Forks", value: res.forks.toString(), inline: true },
+				{ name: "Stars", value: res.stars.toString(), inline: true },
+				{ name: "Watchers", value: res.watchers.toString(), inline: true}
+			]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 			await interaction.reply({embeds: [embed]});
 		} catch (error) {
 			embed.setTitle("Error");
 			embed.setDescription("There was a problem with the request to GitHub.");
-			embed.addField("Correct Usage", "?github <username>/<repository>");
+			embed.addFields([{ name: "Correct Usage", value: "?github <username>/<repository>" }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").ERROR);
 			await interaction.reply({embeds: [embed], ephemeral: true});
 		}

--- a/src/commands/HiringLookingCommand.ts
+++ b/src/commands/HiringLookingCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import {Discord, Slash} from "discordx";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -7,7 +7,7 @@ import GenericObject from "../interfaces/GenericObject";
 class HiringLookingCommand {
 	@Slash("hl")
 	async onInteract(interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		embed.setTitle("Hiring or Looking Posts");
 		embed.setDescription(`
@@ -16,11 +16,20 @@ class HiringLookingCommand {
 			as long as it fits in with the rules. If you get scammed in hiring or looking there is
 			nothing we can do, however, we do ask that you let a moderator know.
 		`);
-		embed.addField("Payment", "If you are trying to hire people for a project, and that project is not open source, your post must state how much you will pay them (or a percentage of profits they will receive).");
-		embed.addField("Post Frequency", `Please only post in <#${getConfigValue<GenericObject<string>>("BOTLESS_CHANNELS").HIRING_OR_LOOKING}> once per week to keep the channel clean and fair. Posting multiple times per week will lead to your access to the channel being revoked.`);
-		embed.addField("Example Post", `
-			Please use the example below as a template to base your post on.\n
-			\`\`\`
+		embed.addFields([
+			{
+				name: "Payment",
+				value: "If you are trying to hire people for a project, and that project is not open source, your post must state how much you will pay them (or a percentage of profits they will receive)."
+			},
+			{
+				name: "Post Frequency",
+				value: `Please only post in <#${getConfigValue<GenericObject<string>>("BOTLESS_CHANNELS").HIRING_OR_LOOKING}> once per week to keep the channel clean and fair. Posting multiple times per week will lead to your access to the channel being revoked.`
+			},
+			{
+				name: "Example Post",
+				value: `
+				Please use the example below as a template to base your post on.\n
+				\`\`\`
 [HIRING]
 Full Stack Website Developer
 We are looking for a developer who is willing to bring our video streaming service to life.
@@ -30,8 +39,10 @@ Requirements:
 - Knowledge of Node.js, Express and EJS.
 - Able to turn Adobe XD design documents into working web pages.
 - Able to stick to deadlines and work as a team.
-			\`\`\`
-		`);
+				\`\`\`
+				`
+			}
+		]);
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 
 		await interaction.reply({ embeds: [embed]});

--- a/src/commands/HiringLookingCommand.ts
+++ b/src/commands/HiringLookingCommand.ts
@@ -28,8 +28,8 @@ class HiringLookingCommand {
 			{
 				name: "Example Post",
 				value: `
-				Please use the example below as a template to base your post on.\n
-				\`\`\`
+			Please use the example below as a template to base your post on.\n
+			\`\`\`
 [HIRING]
 Full Stack Website Developer
 We are looking for a developer who is willing to bring our video streaming service to life.
@@ -39,8 +39,8 @@ Requirements:
 - Knowledge of Node.js, Express and EJS.
 - Able to turn Adobe XD design documents into working web pages.
 - Able to stick to deadlines and work as a team.
-				\`\`\`
-				`
+			\`\`\`
+		`
 			}
 		]);
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);

--- a/src/commands/HiringLookingCommand.ts
+++ b/src/commands/HiringLookingCommand.ts
@@ -5,7 +5,7 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class HiringLookingCommand {
-	@Slash({ name: "hl", description: "Hiring or Looking" })
+	@Slash({ name: "hl", description: "Shows the rules for the hiring/looking section" })
 	async onInteract(interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 

--- a/src/commands/HiringLookingCommand.ts
+++ b/src/commands/HiringLookingCommand.ts
@@ -5,7 +5,7 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class HiringLookingCommand {
-	@Slash("hl")
+	@Slash({ name: "hl", description: "Hiring or Looking" })
 	async onInteract(interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -1,5 +1,5 @@
 import {Discord, Slash, SlashOption} from "discordx";
-import {MessageEmbed, ColorResolvable, CommandInteraction, GuildMember, Formatters} from "discord.js";
+import {EmbedBuilder, ColorResolvable, CommandInteraction, GuildMember, Formatters} from "discord.js";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
 import DiscordUtils from "../utils/DiscordUtils";
@@ -19,39 +19,41 @@ class InspectCommand {
 		await interaction.reply({embeds: [embed]});
 	}
 
-	private buildNoMatchEmbed(): MessageEmbed {
-		const embed = new MessageEmbed();
+	private buildNoMatchEmbed(): EmbedBuilder {
+		const embed = new EmbedBuilder();
 
 		embed.setTitle("Error");
 		embed.setDescription("No match found.");
-		embed.addField("Correct Usage", "?inspect [username|userID]");
+		embed.addFields([{ name: "Correct Usage", value: "?inspect [username|userID]" }]);
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").ERROR);
 
 		return embed;
 	}
 
-	private buildInspectEmbed(memberObj: GuildMember): MessageEmbed {
-		const embed = new MessageEmbed();
+	private buildInspectEmbed(memberObj: GuildMember): EmbedBuilder {
+		const embed = new EmbedBuilder();
 
 		embed.setTitle(`Inspecting ${memberObj?.user.tag}`);
 		embed.setColor(<ColorResolvable>(memberObj?.displayColor || getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT));
 		embed.setThumbnail(memberObj?.user.displayAvatarURL());
-		embed.addField("User ID", memberObj?.user.id);
-		embed.addField("Username", memberObj?.user.tag);
+		embed.addFields([
+			{ name: "User ID", value: memberObj?.user.id },
+			{ name: "Username", value: memberObj?.user.tag }
+		]);
 
-		if (memberObj?.nickname !== null) embed.addField("Nickname", memberObj?.nickname);
+		if (memberObj?.nickname !== null) embed.addFields([{ name: "Nickname", value: memberObj?.nickname }]);
 
 		if (memberObj?.joinedAt !== null) {
 			const shortDateTime = Formatters.time(memberObj?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
 			const relativeTime = Formatters.time(memberObj?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
 
-			embed.addField("Joined At", `${shortDateTime} ${relativeTime}`);
+			embed.addFields([{ name: "Joined At", value: `${shortDateTime} ${relativeTime}` }]);
 		}
 
 		if (memberObj?.roles.cache.size > 1) {
-			embed.addField("Roles", `${memberObj.roles.cache.filter(role => role.id !== memberObj?.guild!.id).map(role => ` ${role.toString()}`)}`);
+			embed.addFields([{ name: "Roles", value: `${memberObj.roles.cache.filter(role => role.id !== memberObj?.guild!.id).map(role => ` ${role.toString()}`)}` }]);
 		} else {
-			embed.addField("Roles", "No roles");
+			embed.addFields([{ name: "Roles", value: "No roles" }]);
 		}
 
 		return embed;

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -1,5 +1,5 @@
 import {Discord, Slash, SlashOption} from "discordx";
-import {EmbedBuilder, ColorResolvable, CommandInteraction, GuildMember, Formatters} from "discord.js";
+import {EmbedBuilder, ColorResolvable, CommandInteraction, GuildMember, Formatters, ApplicationCommandOptionType} from "discord.js";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
 import DiscordUtils from "../utils/DiscordUtils";
@@ -8,7 +8,7 @@ import DiscordUtils from "../utils/DiscordUtils";
 class InspectCommand {
 	@Slash("inspect")
 	async onInteract(
-		@SlashOption("user", {type: "MENTIONABLE", required: false}) userID: GuildMember,
+		@SlashOption("user", {type: ApplicationCommandOptionType.Mentionable, required: false}) userID: GuildMember,
 			interaction: CommandInteraction): Promise<void> {
 		const userObj = await DiscordUtils.getGuildMember(userID === undefined ? interaction.user.id : userID.id, interaction.guild!);
 

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -6,10 +6,10 @@ import DiscordUtils from "../utils/DiscordUtils";
 
 @Discord()
 class InspectCommand {
-	@Slash({ name: "inspect", description: "Inspect a User" })
+	@Slash({ name: "inspect", description: "Inspect a user" })
 	async onInteract(
-		interaction: CommandInteraction,
-		@SlashOption({ name: "user", description: "User", type: ApplicationCommandOptionType.Mentionable, required: false }) userID?: GuildMember
+		@SlashOption({ name: "user", description: "User to inspect", type: ApplicationCommandOptionType.Mentionable, required: false }) userID: GuildMember | undefined,
+		interaction: CommandInteraction
 	): Promise<void> {
 		const userObj = await DiscordUtils.getGuildMember(userID === undefined ? interaction.user.id : userID.id, interaction.guild!);
 

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -6,10 +6,11 @@ import DiscordUtils from "../utils/DiscordUtils";
 
 @Discord()
 class InspectCommand {
-	@Slash("inspect")
+	@Slash({ name: "inspect", description: "Inspect a User" })
 	async onInteract(
-		@SlashOption("user", {type: ApplicationCommandOptionType.Mentionable, required: false}) userID: GuildMember,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashOption({ name: "user", description: "User", type: ApplicationCommandOptionType.Mentionable, required: false }) userID: GuildMember,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const userObj = await DiscordUtils.getGuildMember(userID === undefined ? interaction.user.id : userID.id, interaction.guild!);
 
 		const embed = userObj === undefined

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -8,8 +8,8 @@ import DiscordUtils from "../utils/DiscordUtils";
 class InspectCommand {
 	@Slash({ name: "inspect", description: "Inspect a User" })
 	async onInteract(
-		@SlashOption({ name: "user", description: "User", type: ApplicationCommandOptionType.Mentionable, required: false }) userID: GuildMember,
-		interaction: CommandInteraction
+		interaction: CommandInteraction,
+		@SlashOption({ name: "user", description: "User", type: ApplicationCommandOptionType.Mentionable, required: false }) userID?: GuildMember
 	): Promise<void> {
 		const userObj = await DiscordUtils.getGuildMember(userID === undefined ? interaction.user.id : userID.id, interaction.guild!);
 

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -1,5 +1,5 @@
 import {Discord, Slash, SlashOption} from "discordx";
-import {EmbedBuilder, ColorResolvable, CommandInteraction, GuildMember, Formatters, ApplicationCommandOptionType} from "discord.js";
+import {EmbedBuilder, ColorResolvable, CommandInteraction, GuildMember, time, TimestampStyles, ApplicationCommandOptionType} from "discord.js";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
 import DiscordUtils from "../utils/DiscordUtils";
@@ -45,8 +45,8 @@ class InspectCommand {
 		if (memberObj?.nickname !== null) embed.addFields([{ name: "Nickname", value: memberObj?.nickname }]);
 
 		if (memberObj?.joinedAt !== null) {
-			const shortDateTime = Formatters.time(memberObj?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
-			const relativeTime = Formatters.time(memberObj?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
+			const shortDateTime = time(memberObj?.joinedAt!, TimestampStyles.ShortDateTime);
+			const relativeTime = time(memberObj?.joinedAt!, TimestampStyles.RelativeTime);
 
 			embed.addFields([{ name: "Joined At", value: `${shortDateTime} ${relativeTime}` }]);
 		}

--- a/src/commands/IssuesCommand.ts
+++ b/src/commands/IssuesCommand.ts
@@ -9,11 +9,12 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class IssuesCommand {
-	@Slash("issues")
+	@Slash({ name: "issues", description: "Issues of a Github repository" })
 	async onInteract(
-		@SlashOption("user", {type: ApplicationCommandOptionType.String}) user: string,
-		@SlashOption("repository", {type: ApplicationCommandOptionType.String}) repoName: string,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashOption({ name: "user", description: "Github user/account", type: ApplicationCommandOptionType.String, required: true }) user: string,
+		@SlashOption({ name: "repository", description: "Github repository", type: ApplicationCommandOptionType.String, required: true }) repoName: string,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const embed = new EmbedBuilder();
 
 		try {

--- a/src/commands/IssuesCommand.ts
+++ b/src/commands/IssuesCommand.ts
@@ -9,7 +9,7 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class IssuesCommand {
-	@Slash({ name: "issues", description: "Issues of a Github repository" })
+	@Slash({ name: "issues", description: "Shows the open issues on a GitHub repository" })
 	async onInteract(
 		@SlashOption({ name: "user", description: "Github user/account", type: ApplicationCommandOptionType.String, required: true }) user: string,
 		@SlashOption({ name: "repository", description: "Github repository", type: ApplicationCommandOptionType.String, required: true }) repoName: string,

--- a/src/commands/IssuesCommand.ts
+++ b/src/commands/IssuesCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 import GitHubService from "../services/GitHubService";
 import GitHubIssue from "../interfaces/GitHubIssue";
@@ -14,7 +14,7 @@ class IssuesCommand {
 		@SlashOption("user", {type: "STRING"}) user: string,
 		@SlashOption("repository", {type: "STRING"}) repoName: string,
 			interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		try {
 			const GitHub = GitHubService.getInstance();
@@ -31,7 +31,12 @@ class IssuesCommand {
 					const days = DateUtils.getDaysBetweenDates(new Date(Date.now()), issue.created_at);
 					const daysText = StringUtils.capitalise(DateUtils.formatDaysAgo(days));
 
-					embed.addField(`#${issue.number} - ${issue.title}`, `View on [GitHub](${issue.issue_url}) - ${daysText} by [${issue.author}](${issue.author_url})`);
+					embed.addFields([
+						{
+							name: `#${issue.number} - ${issue.title}`,
+							value: `View on [GitHub](${issue.issue_url}) - ${daysText} by [${issue.author}](${issue.author_url})`
+						}
+					]);
 				});
 
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
@@ -43,7 +48,7 @@ class IssuesCommand {
 		} catch (error) {
 			embed.setTitle("Error");
 			embed.setDescription("There was a problem with the request to GitHub.");
-			embed.addField("Correct Usage", "/issues <username>/<repository>");
+			embed.addFields([{ name: "Correct Usage", value: "/issues <username>/<repository>" }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").ERROR);
 		}
 		await interaction.reply({ embeds: [embed] });

--- a/src/commands/IssuesCommand.ts
+++ b/src/commands/IssuesCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 import GitHubService from "../services/GitHubService";
 import GitHubIssue from "../interfaces/GitHubIssue";
@@ -11,8 +11,8 @@ import GenericObject from "../interfaces/GenericObject";
 class IssuesCommand {
 	@Slash("issues")
 	async onInteract(
-		@SlashOption("user", {type: "STRING"}) user: string,
-		@SlashOption("repository", {type: "STRING"}) repoName: string,
+		@SlashOption("user", {type: ApplicationCommandOptionType.String}) user: string,
+		@SlashOption("repository", {type: ApplicationCommandOptionType.String}) repoName: string,
 			interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 

--- a/src/commands/NPMCommand.ts
+++ b/src/commands/NPMCommand.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -10,7 +10,7 @@ class NPMCommand {
 	async onInteract(
 		@SlashOption("package", {type: "STRING"}) packageName: string,
 			interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		try {
 			const url = `https://www.npmjs.com/package/${packageName}`;

--- a/src/commands/NPMCommand.ts
+++ b/src/commands/NPMCommand.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -8,7 +8,7 @@ import GenericObject from "../interfaces/GenericObject";
 class NPMCommand {
 	@Slash("npm")
 	async onInteract(
-		@SlashOption("package", {type: "STRING"}) packageName: string,
+		@SlashOption("package", {type: ApplicationCommandOptionType.String}) packageName: string,
 			interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 

--- a/src/commands/NPMCommand.ts
+++ b/src/commands/NPMCommand.ts
@@ -6,10 +6,11 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class NPMCommand {
-	@Slash("npm")
+	@Slash({ name: "npm", description: "Get an npm package url" })
 	async onInteract(
-		@SlashOption("package", {type: ApplicationCommandOptionType.String}) packageName: string,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashOption({ name: "package", description: "Package name", type: ApplicationCommandOptionType.String, required: true }) packageName: string,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const embed = new EmbedBuilder();
 
 		try {

--- a/src/commands/ProjectCommand.ts
+++ b/src/commands/ProjectCommand.ts
@@ -1,5 +1,5 @@
 import {Discord, Slash, SlashOption} from "discordx";
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import Project from "../interfaces/Project";
 import projects from "../src-assets/projects.json";
 import StringUtils from "../utils/StringUtils";
@@ -16,7 +16,7 @@ class ProjectCommand {
 	async onInteract(
 		@SlashOption("query", {type: "STRING"}) queryString: string,
 			interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 		let ephemeralFlag = false;
 		const query = queryString.split(" ").map((arg: string) => arg.toLowerCase()).filter((arg: string) => arg.trim().length > 0);
 		const usageDescription = `Use a difficulty or try out a tag to find a random project! The available difficulties are ${this.defaultSearchTags.map(tag => `\`${tag}\``).join(", ")}. A possible tag to use can be \`frontend\`, \`backend\`, \`spa\`, etc.`;
@@ -24,7 +24,7 @@ class ProjectCommand {
 		if (query.length === 0) {
 			embed.setTitle("Error");
 			embed.setDescription("You must provide a search query/tag.");
-			embed.addField("Usage", usageDescription);
+			embed.addFields([{ name: "Usage", value: usageDescription }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").ERROR);
 			ephemeralFlag = true;
 		} else {
@@ -38,14 +38,14 @@ class ProjectCommand {
 
 				embed.setTitle(`Project: ${displayProject.title}`);
 				embed.setDescription(displayProject.description);
-				if (difficulty) embed.addField("Difficulty", StringUtils.capitalise(difficulty), true);
-				embed.addField("Tags", displayProject.tags.map(tag => `#${tag}`).join(", "), true);
+				if (difficulty) embed.addFields([{ name: "Difficulty", value: StringUtils.capitalise(difficulty), inline: true }]);
+				embed.addFields([{ name: "Tags", value: displayProject.tags.map(tag => `#${tag}`).join(", "), inline: true }]);
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 			} else {
 				embed.setTitle("Error");
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").ERROR);
 				embed.setDescription("Could not find a project result for the given query.");
-				embed.addField("Usage", usageDescription);
+				embed.addFields([{ name: "Usage", value: usageDescription }]);
 				ephemeralFlag = true;
 			}
 		}

--- a/src/commands/ProjectCommand.ts
+++ b/src/commands/ProjectCommand.ts
@@ -12,10 +12,11 @@ class ProjectCommand {
 
 	readonly provideProjects: () => Array<Project> = () => projects;
 
-	@Slash("project")
+	@Slash({ name: "project", description: "Get a random project idea" })
 	async onInteract(
-		@SlashOption("query", {type: ApplicationCommandOptionType.String}) queryString: string,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashOption({ name: "query", description: "Query search", type: ApplicationCommandOptionType.String, required: true }) queryString: string,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const embed = new EmbedBuilder();
 		let ephemeralFlag = false;
 		const query = queryString.split(" ").map((arg: string) => arg.toLowerCase()).filter((arg: string) => arg.trim().length > 0);

--- a/src/commands/ProjectCommand.ts
+++ b/src/commands/ProjectCommand.ts
@@ -1,5 +1,5 @@
 import {Discord, Slash, SlashOption} from "discordx";
-import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
 import Project from "../interfaces/Project";
 import projects from "../src-assets/projects.json";
 import StringUtils from "../utils/StringUtils";
@@ -14,7 +14,7 @@ class ProjectCommand {
 
 	@Slash("project")
 	async onInteract(
-		@SlashOption("query", {type: "STRING"}) queryString: string,
+		@SlashOption("query", {type: ApplicationCommandOptionType.String}) queryString: string,
 			interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 		let ephemeralFlag = false;

--- a/src/commands/ResourcesCommand.ts
+++ b/src/commands/ResourcesCommand.ts
@@ -1,12 +1,13 @@
 import { Discord, Slash, SlashOption } from "discordx";
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, ApplicationCommandOptionType } from "discord.js";
 
 @Discord()
 class ResourcesCommand {
-	@Slash("resources")
+	@Slash({ name: "resources", description: "Resources on the Codesupport site" })
 	async onInteract(
-		@SlashOption("category", { required: false }) category: string, interaction: CommandInteraction
-	) {
+		interaction: CommandInteraction,
+		@SlashOption({ name: "category", description: "Resource category", type: ApplicationCommandOptionType.String, required: false }) category?: string
+	): Promise<void> {
 		let url = "https://codesupport.dev/resources";
 
 		if (category) {

--- a/src/commands/ResourcesCommand.ts
+++ b/src/commands/ResourcesCommand.ts
@@ -3,7 +3,7 @@ import { CommandInteraction, ApplicationCommandOptionType } from "discord.js";
 
 @Discord()
 class ResourcesCommand {
-	@Slash({ name: "resources", description: "Resources on the Codesupport site" })
+	@Slash({ name: "resources", description: "Resources on the CodeSupport site" })
 	async onInteract(
 		@SlashOption({ name: "category", description: "Resource category", type: ApplicationCommandOptionType.String, required: false }) category: string | undefined,
 		interaction: CommandInteraction

--- a/src/commands/ResourcesCommand.ts
+++ b/src/commands/ResourcesCommand.ts
@@ -5,8 +5,8 @@ import { CommandInteraction, ApplicationCommandOptionType } from "discord.js";
 class ResourcesCommand {
 	@Slash({ name: "resources", description: "Resources on the Codesupport site" })
 	async onInteract(
-		interaction: CommandInteraction,
-		@SlashOption({ name: "category", description: "Resource category", type: ApplicationCommandOptionType.String, required: false }) category?: string
+		@SlashOption({ name: "category", description: "Resource category", type: ApplicationCommandOptionType.String, required: false }) category: string | undefined,
+		interaction: CommandInteraction
 	): Promise<void> {
 		let url = "https://codesupport.dev/resources";
 

--- a/src/commands/RuleCommand.ts
+++ b/src/commands/RuleCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import {Discord, Slash, SlashChoice, SlashOption} from "discordx";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -17,14 +17,14 @@ class RuleCommand {
 	async onInteract(
 		@SlashChoice(...rules) @SlashOption("rule") ruleName: string,
 			interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		const rule = getConfigValue<Rule[]>("rules").find(rule => rule.triggers.includes(ruleName));
 
 		if (rule !== undefined) {
 			embed.setTitle(`Rule: ${rule.name}`);
 			embed.setDescription(rule.description);
-			embed.addField("To familiarise yourself with all of the server's rules please see", "<#240884566519185408>");
+			embed.addFields([{ name: "To familiarise yourself with all of the server's rules please see", value: "<#240884566519185408>" }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 		}
 		await interaction.reply({embeds: [embed]});

--- a/src/commands/RuleCommand.ts
+++ b/src/commands/RuleCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
 import {Discord, Slash, SlashChoice, SlashOption} from "discordx";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -13,10 +13,11 @@ const rules = getConfigValue<Rule[]>("rules").map(it => ({name: it.name, value: 
 
 @Discord()
 class RuleCommand {
-	@Slash("rule")
+	@Slash({ name: "rule", description: "Get info about a rule" })
 	async onInteract(
-		@SlashChoice(...rules) @SlashOption("rule") ruleName: string,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashChoice(...rules) @SlashOption({ name: "rule", description: "Name of a rule", type: ApplicationCommandOptionType.String, required: true }) ruleName: string,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const embed = new EmbedBuilder();
 
 		const rule = getConfigValue<Rule[]>("rules").find(rule => rule.triggers.includes(ruleName));

--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -6,10 +6,11 @@ import GenericObject from "../interfaces/GenericObject";
 
 @Discord()
 class SearchCommand {
-	@Slash("search")
+	@Slash({ name: "search", description: "Search using the DuckDuckGo API" })
 	async onInteract(
-		@SlashOption("query", {type: ApplicationCommandOptionType.String, required: false}) query: string,
-			interaction: CommandInteraction): Promise<void> {
+		@SlashOption({ name: "query", description: "Search query", type: ApplicationCommandOptionType.String, required: true }) query: string,
+		interaction: CommandInteraction
+	): Promise<void> {
 		const embed = new EmbedBuilder();
 
 		try {

--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, MessageEmbed} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 import InstantAnswerService from "../services/InstantAnswerService";
 import getConfigValue from "../utils/getConfigValue";
@@ -10,7 +10,7 @@ class SearchCommand {
 	async onInteract(
 		@SlashOption("query", {type: "STRING", required: false}) query: string,
 			interaction: CommandInteraction): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		try {
 			const InstantAnswer = InstantAnswerService.getInstance();
@@ -21,7 +21,7 @@ class SearchCommand {
 
 				embed.setTitle(res.heading);
 				embed.setDescription(`${res.description}\n\n[View on ${baseURL}](${res.url})`);
-				embed.setFooter("Result powered by the DuckDuckGo API.");
+				embed.setFooter({ text: "Result powered by the DuckDuckGo API." });
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 			} else {
 				embed.setTitle("Error");
@@ -31,7 +31,7 @@ class SearchCommand {
 		} catch (error) {
 			embed.setTitle("Error");
 			embed.setDescription("There was a problem querying DuckDuckGo.");
-			embed.addField("Correct Usage", "/search <query>");
+			embed.addFields([{ name: "Correct Usage", value: "/search <query>" }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").ERROR);
 		}
 		await interaction.reply({embeds: [embed]});

--- a/src/commands/SearchCommand.ts
+++ b/src/commands/SearchCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, EmbedBuilder} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 import InstantAnswerService from "../services/InstantAnswerService";
 import getConfigValue from "../utils/getConfigValue";
@@ -8,7 +8,7 @@ import GenericObject from "../interfaces/GenericObject";
 class SearchCommand {
 	@Slash("search")
 	async onInteract(
-		@SlashOption("query", {type: "STRING", required: false}) query: string,
+		@SlashOption("query", {type: ApplicationCommandOptionType.String, required: false}) query: string,
 			interaction: CommandInteraction): Promise<void> {
 		const embed = new EmbedBuilder();
 

--- a/src/commands/WebsiteCommand.ts
+++ b/src/commands/WebsiteCommand.ts
@@ -3,10 +3,11 @@ import {Discord, Slash, SlashOption} from "discordx";
 
 @Discord()
 class WebsiteCommand {
-	@Slash("website")
+	@Slash({ name: "website", description: "URL of the Codesupport website" })
 	async onInteract(
-		@SlashOption("path", {type: ApplicationCommandOptionType.String, required: false}) path: string,
-			interaction: CommandInteraction): Promise<void> {
+		interaction: CommandInteraction,
+		@SlashOption({ name: "path", description: "Path to add to the URL", type: ApplicationCommandOptionType.String, required: false }) path?: string
+	): Promise<void> {
 		await interaction.reply(`https://codesupport.dev/${path || ""}`);
 	}
 }

--- a/src/commands/WebsiteCommand.ts
+++ b/src/commands/WebsiteCommand.ts
@@ -5,8 +5,8 @@ import {Discord, Slash, SlashOption} from "discordx";
 class WebsiteCommand {
 	@Slash({ name: "website", description: "URL of the Codesupport website" })
 	async onInteract(
-		interaction: CommandInteraction,
-		@SlashOption({ name: "path", description: "Path to add to the URL", type: ApplicationCommandOptionType.String, required: false }) path?: string
+		@SlashOption({ name: "path", description: "Path to add to the URL", type: ApplicationCommandOptionType.String, required: false }) path: string | undefined,
+		interaction: CommandInteraction
 	): Promise<void> {
 		await interaction.reply(`https://codesupport.dev/${path || ""}`);
 	}

--- a/src/commands/WebsiteCommand.ts
+++ b/src/commands/WebsiteCommand.ts
@@ -1,11 +1,11 @@
-import {CommandInteraction} from "discord.js";
+import {CommandInteraction, ApplicationCommandOptionType} from "discord.js";
 import {Discord, Slash, SlashOption} from "discordx";
 
 @Discord()
 class WebsiteCommand {
 	@Slash("website")
 	async onInteract(
-		@SlashOption("path", {type: "STRING", required: false}) path: string,
+		@SlashOption("path", {type: ApplicationCommandOptionType.String, required: false}) path: string,
 			interaction: CommandInteraction): Promise<void> {
 		await interaction.reply(`https://codesupport.dev/${path || ""}`);
 	}

--- a/src/commands/WebsiteCommand.ts
+++ b/src/commands/WebsiteCommand.ts
@@ -3,7 +3,7 @@ import {Discord, Slash, SlashOption} from "discordx";
 
 @Discord()
 class WebsiteCommand {
-	@Slash({ name: "website", description: "URL of the Codesupport website" })
+	@Slash({ name: "website", description: "URL of the CodeSupport website" })
 	async onInteract(
 		@SlashOption({ name: "path", description: "Path to add to the URL", type: ApplicationCommandOptionType.String, required: false }) path: string | undefined,
 		interaction: CommandInteraction

--- a/src/event/handlers/AutomaticMemberRoleHandler.ts
+++ b/src/event/handlers/AutomaticMemberRoleHandler.ts
@@ -1,10 +1,10 @@
-import {Constants, GuildMember, RoleResolvable} from "discord.js";
+import {Events, GuildMember, RoleResolvable} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 
 class AutomaticMemberRoleHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.GUILD_MEMBER_ADD);
+		super(Events.GuildMemberAdd);
 	}
 
 	async handle(member: GuildMember): Promise<void> {

--- a/src/event/handlers/CodeblocksOverFileUploadsHandler.ts
+++ b/src/event/handlers/CodeblocksOverFileUploadsHandler.ts
@@ -1,11 +1,11 @@
-import {Constants, EmbedBuilder, Message, ColorResolvable} from "discord.js";
+import {Events, EmbedBuilder, Message, ColorResolvable} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
 
 class CodeblocksOverFileUploadsHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_CREATE);
+		super(Events.MessageCreate);
 	}
 
 	async handle(message: Message): Promise<void> {

--- a/src/event/handlers/CodeblocksOverFileUploadsHandler.ts
+++ b/src/event/handlers/CodeblocksOverFileUploadsHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, MessageEmbed, Message, ColorResolvable} from "discord.js";
+import {Constants, EmbedBuilder, Message, ColorResolvable} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
@@ -25,11 +25,11 @@ class CodeblocksOverFileUploadsHandler extends EventHandler {
 			});
 
 			if (invalidFileFlag) {
-				const embed = new MessageEmbed();
+				const embed = new EmbedBuilder();
 
 				embed.setTitle("Uploading Files");
 				embed.setDescription(`${message.author}, you tried to upload a \`.${invalidFileExtension}\` file, which is not allowed. Please use codeblocks over attachments when sending code.`);
-				embed.setFooter("Type /codeblock for more information.");
+				embed.setFooter({ text: "Type /codeblock for more information." });
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 
 				await message.channel.send({ embeds: [embed] });

--- a/src/event/handlers/DiscordMessageLinkHandler.ts
+++ b/src/event/handlers/DiscordMessageLinkHandler.ts
@@ -1,10 +1,10 @@
 import EventHandler from "../../abstracts/EventHandler";
-import { Message, Constants } from "discord.js";
+import { Message, Events } from "discord.js";
 import MessagePreviewService from "../../services/MessagePreviewService";
 
 class DiscordMessageLinkHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_CREATE);
+		super(Events.MessageCreate);
 	}
 
 	async handle(message: Message): Promise<void> {

--- a/src/event/handlers/GhostPingDeleteHandler.ts
+++ b/src/event/handlers/GhostPingDeleteHandler.ts
@@ -1,4 +1,4 @@
-import {Events, EmbedBuilder, Message, User, TextChannel, ColorResolvable} from "discord.js";
+import {Events, EmbedBuilder, Message, User, ColorResolvable, ChannelType} from "discord.js";
 import DateUtils from "../../utils/DateUtils";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
@@ -24,7 +24,7 @@ class GhostPingDeleteHandler extends EventHandler {
 				if (message.reference?.messageId && message.reference.guildId === message.guild?.id) {
 					const repliedToChannel = message.guild?.channels.resolve(message.reference.channelId);
 
-					if (repliedToChannel instanceof TextChannel) {
+					if (repliedToChannel?.type === ChannelType.GuildText) {
 						repliedToMessage = await repliedToChannel.messages.fetch(message.reference.messageId);
 						repliedToUser = repliedToMessage?.author;
 					}

--- a/src/event/handlers/GhostPingDeleteHandler.ts
+++ b/src/event/handlers/GhostPingDeleteHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, MessageEmbed, Message, User, TextChannel, ColorResolvable} from "discord.js";
+import {Constants, EmbedBuilder, Message, User, TextChannel, ColorResolvable} from "discord.js";
 import DateUtils from "../../utils/DateUtils";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
@@ -16,7 +16,7 @@ class GhostPingDeleteHandler extends EventHandler {
 
 				if (usersMentioned.every(user => user.id === message.author.id || user.bot)) return;
 
-				const embed = new MessageEmbed();
+				const embed = new EmbedBuilder();
 
 				let repliedToMessage : Message | null | undefined = null;
 				let repliedToUser: User | null | undefined = null;
@@ -33,16 +33,24 @@ class GhostPingDeleteHandler extends EventHandler {
 				embed.setTitle("Ghost Ping Detected!");
 
 				if (repliedToUser !== null && repliedToUser !== undefined) {
-					embed.addField("Author", message.author.toString(), true);
-					embed.addField("Reply to", repliedToUser.toString(), true);
+					embed.addFields([
+						{ name: "Author", value: message.author.toString(), inline: true },
+						{ name: "Reply to", value: repliedToUser.toString(), inline: true }
+					]);
 				} else {
-					embed.addField("Author", message.author.toString());
+					embed.addFields([{ name: "Author", value: message.author.toString() }]);
 				}
 
-				embed.addField("Message", message.content);
+				embed.addFields([{ name: "Message", value: message.content }]);
 
 				if (repliedToMessage !== null && repliedToMessage !== undefined && repliedToMessage !== null) {
-					embed.addField("Message replied to", `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`, true);
+					embed.addFields([
+						{
+							name: "Message replied to",
+							value: `https://discord.com/channels/${repliedToMessage.guild?.id}/${repliedToMessage.channel.id}/${repliedToMessage.id}`,
+							inline: true
+						}
+					]);
 				}
 
 				embed.setFooter({ text: `Message sent at ${DateUtils.formatAsText(message.createdAt)}` });

--- a/src/event/handlers/GhostPingDeleteHandler.ts
+++ b/src/event/handlers/GhostPingDeleteHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, EmbedBuilder, Message, User, TextChannel, ColorResolvable} from "discord.js";
+import {Events, EmbedBuilder, Message, User, TextChannel, ColorResolvable} from "discord.js";
 import DateUtils from "../../utils/DateUtils";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
@@ -6,7 +6,7 @@ import GenericObject from "../../interfaces/GenericObject";
 
 class GhostPingDeleteHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_DELETE);
+		super(Events.MessageDelete);
 	}
 
 	async handle(message: Message): Promise<void> {

--- a/src/event/handlers/GhostPingUpdateHandler.ts
+++ b/src/event/handlers/GhostPingUpdateHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, MessageEmbed, Message, ColorResolvable, MessageActionRow, MessageButton} from "discord.js";
+import {Constants, EmbedBuilder, Message, ColorResolvable, MessageActionRow, MessageButton} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import DateUtils from "../../utils/DateUtils";
 import getConfigValue from "../../utils/getConfigValue";
@@ -23,12 +23,14 @@ class GhostPingUpdateHandler extends EventHandler {
 		button.setURL(newMessage.url);
 
 		const row = new MessageActionRow().addComponents(button);
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		embed.setTitle("Ghost Ping Detected!");
-		embed.addField("Author", oldMessage.author.toString());
-		embed.addField("Previous message", oldMessage.content);
-		embed.addField("Edited message", newMessage.content);
+		embed.addFields([
+			{ name: "Author", value: oldMessage.author.toString() },
+			{ name: "Previous message", value: oldMessage.content },
+			{ name: "Edited message", value: newMessage.content }
+		]);
 		embed.setFooter({ text: `Message edited at ${DateUtils.formatAsText(newMessage.createdAt)}` });
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 

--- a/src/event/handlers/GhostPingUpdateHandler.ts
+++ b/src/event/handlers/GhostPingUpdateHandler.ts
@@ -22,7 +22,7 @@ class GhostPingUpdateHandler extends EventHandler {
 		button.setStyle(ButtonStyle.Link);
 		button.setURL(newMessage.url);
 
-		const row = new ActionRowBuilder().addComponents(button);
+		const row = new ActionRowBuilder<ButtonBuilder>().addComponents(button);
 		const embed = new EmbedBuilder();
 
 		embed.setTitle("Ghost Ping Detected!");

--- a/src/event/handlers/GhostPingUpdateHandler.ts
+++ b/src/event/handlers/GhostPingUpdateHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, EmbedBuilder, Message, ColorResolvable, MessageActionRow, MessageButton} from "discord.js";
+import {Events, ButtonStyle, EmbedBuilder, Message, ColorResolvable, MessageActionRow, ButtonBuilder} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import DateUtils from "../../utils/DateUtils";
 import getConfigValue from "../../utils/getConfigValue";
@@ -6,7 +6,7 @@ import GenericObject from "../../interfaces/GenericObject";
 
 class GhostPingUpdateHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_UPDATE);
+		super(Events.MessageUpdate);
 	}
 
 	async handle(oldMessage: Message, newMessage: Message): Promise<void> {
@@ -16,10 +16,10 @@ class GhostPingUpdateHandler extends EventHandler {
 
 		if (removedMentions.size === 0 || removedMentions.every(user => user.id === oldMessage.author.id || user.bot)) return;
 
-		const button = new MessageButton();
+		const button = new ButtonBuilder();
 
 		button.setLabel("View Edited Message");
-		button.setStyle(Constants.MessageButtonStyles.LINK);
+		button.setStyle(ButtonStyle.Link);
 		button.setURL(newMessage.url);
 
 		const row = new MessageActionRow().addComponents(button);

--- a/src/event/handlers/GhostPingUpdateHandler.ts
+++ b/src/event/handlers/GhostPingUpdateHandler.ts
@@ -1,4 +1,4 @@
-import {Events, ButtonStyle, EmbedBuilder, Message, ColorResolvable, MessageActionRow, ButtonBuilder} from "discord.js";
+import {Events, ButtonStyle, EmbedBuilder, Message, ColorResolvable, ActionRowBuilder, ButtonBuilder} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import DateUtils from "../../utils/DateUtils";
 import getConfigValue from "../../utils/getConfigValue";
@@ -22,7 +22,7 @@ class GhostPingUpdateHandler extends EventHandler {
 		button.setStyle(ButtonStyle.Link);
 		button.setURL(newMessage.url);
 
-		const row = new MessageActionRow().addComponents(button);
+		const row = new ActionRowBuilder().addComponents(button);
 		const embed = new EmbedBuilder();
 
 		embed.setTitle("Ghost Ping Detected!");

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, Constants, GuildMember, MessageEmbed, TextChannel, Snowflake } from "discord.js";
+import { ColorResolvable, Constants, GuildMember, EmbedBuilder, TextChannel, Snowflake } from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import DateUtils from "../../utils/DateUtils";
 import getConfigValue from "../../utils/getConfigValue";
@@ -10,15 +10,17 @@ class LogMemberLeaveHandler extends EventHandler {
 	}
 
 	async handle(guildMember: GuildMember): Promise<void> {
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		embed.setTitle("Member Left");
 		embed.setDescription(`User: ${guildMember.user}`);
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
-		embed.addField("Join Date", new Date(guildMember.joinedTimestamp!).toLocaleString(), true);
-		embed.addField("Leave Date", new Date(Date.now()).toLocaleString(), true);
-		embed.addField("Time In Server", DateUtils.getFormattedTimeSinceDate(guildMember.joinedAt!, new Date(Date.now()))!);
-		embed.addField("Authenticated", guildMember.roles.cache.has(getConfigValue<Snowflake>("MEMBER_ROLE")) ? "True" : "False");
+		embed.addFields([
+			{ name: "Join Date", value: new Date(guildMember.joinedTimestamp!).toLocaleString(), inline: true },
+			{ name: "Leave Date", value: new Date(Date.now()).toLocaleString(), inline: true },
+			{ name: "Time In Server", value: DateUtils.getFormattedTimeSinceDate(guildMember.joinedAt!, new Date(Date.now()))! },
+			{ name: "Authenticated", value: guildMember.roles.cache.has(getConfigValue<Snowflake>("MEMBER_ROLE")) ? "True" : "False" }
+		]);
 
 		const logsChannel = guildMember.guild?.channels.cache.find(
 			channel => channel.id === getConfigValue<string>("LOG_CHANNEL_ID")

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -1,4 +1,4 @@
-import { ColorResolvable, Constants, GuildMember, EmbedBuilder, TextChannel, Snowflake } from "discord.js";
+import { ColorResolvable, Events, GuildMember, EmbedBuilder, TextChannel, Snowflake } from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import DateUtils from "../../utils/DateUtils";
 import getConfigValue from "../../utils/getConfigValue";
@@ -6,7 +6,7 @@ import GenericObject from "../../interfaces/GenericObject";
 
 class LogMemberLeaveHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.GUILD_MEMBER_REMOVE);
+		super(Events.GuildMemberRemove);
 	}
 
 	async handle(guildMember: GuildMember): Promise<void> {

--- a/src/event/handlers/LogMessageBulkDeleteHandler.ts
+++ b/src/event/handlers/LogMessageBulkDeleteHandler.ts
@@ -1,9 +1,9 @@
-import { Collection, Constants, Message, Snowflake } from "discord.js";
+import { Collection, Events, Message, Snowflake } from "discord.js";
 import LogMessageDeleteHandler from "../../abstracts/LogMessageDeleteHandler";
 
 class LogMessageBulkDeleteHandler extends LogMessageDeleteHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_BULK_DELETE);
+		super(Events.MessageBulkDelete);
 	}
 
 	async handle(messages: Collection<Snowflake, Message>): Promise<void> {

--- a/src/event/handlers/LogMessageSingleDeleteHandler.ts
+++ b/src/event/handlers/LogMessageSingleDeleteHandler.ts
@@ -1,9 +1,9 @@
-import { Constants, Message } from "discord.js";
+import { Events, Message } from "discord.js";
 import LogMessageDeleteHandler from "../../abstracts/LogMessageDeleteHandler";
 
 class LogMessageSingleDeleteHandler extends LogMessageDeleteHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_DELETE);
+		super(Events.MessageDelete);
 	}
 
 	async handle(message: Message): Promise<void> {

--- a/src/event/handlers/LogMessageUpdateHandler.ts
+++ b/src/event/handlers/LogMessageUpdateHandler.ts
@@ -1,4 +1,4 @@
-import {Constants, MessageEmbed, Message, TextChannel, ColorResolvable} from "discord.js";
+import {Constants, EmbedBuilder, Message, TextChannel, ColorResolvable} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
@@ -17,12 +17,14 @@ class LogMessageUpdateHandler extends EventHandler {
 			return;
 		}
 
-		const embed = new MessageEmbed();
+		const embed = new EmbedBuilder();
 
 		embed.setTitle("Message Updated");
 		embed.setDescription(`Author: ${oldMessage.author}\nChannel: ${oldMessage.channel}`);
-		embed.addField("Old Message", oldMessage.content);
-		embed.addField("New Message", newMessage.content);
+		embed.addFields([
+			{ name: "Old Message", value: oldMessage.content },
+			{ name: "New Message", value: newMessage.content }
+		]);
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 
 		const logsChannel = oldMessage.guild?.channels.cache.find(

--- a/src/event/handlers/LogMessageUpdateHandler.ts
+++ b/src/event/handlers/LogMessageUpdateHandler.ts
@@ -1,11 +1,11 @@
-import {Constants, EmbedBuilder, Message, TextChannel, ColorResolvable} from "discord.js";
+import {Events, EmbedBuilder, Message, TextChannel, ColorResolvable} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
 
 class LogMessageUpdateHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_UPDATE);
+		super(Events.MessageUpdate);
 	}
 
 	async handle(oldMessage: Message, newMessage: Message): Promise<void> {

--- a/src/event/handlers/NewUserAuthenticationHandler.ts
+++ b/src/event/handlers/NewUserAuthenticationHandler.ts
@@ -1,10 +1,10 @@
-import {Constants, MessageReaction, RoleResolvable, User} from "discord.js";
+import {Events, MessageReaction, RoleResolvable, User} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 
 class NewUserAuthenticationHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_REACTION_ADD);
+		super(Events.MessageReactionAdd);
 	}
 
 	async handle(reaction: MessageReaction, member: User): Promise<void> {

--- a/src/event/handlers/RaidDetectionHandler.ts
+++ b/src/event/handlers/RaidDetectionHandler.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, Constants, GuildMember, EmbedBuilder, TextChannel} from "discord.js";
+import {ColorResolvable, Events, GuildMember, EmbedBuilder, TextChannel} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
@@ -8,7 +8,7 @@ class RaidDetectionHandler extends EventHandler {
 	private kickFlag = false;
 
 	constructor() {
-		super(Constants.Events.GUILD_MEMBER_ADD);
+		super(Events.GuildMemberAdd);
 	}
 
 	handle = async (member: GuildMember): Promise<void> => {

--- a/src/event/handlers/RaidDetectionHandler.ts
+++ b/src/event/handlers/RaidDetectionHandler.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, Constants, GuildMember, MessageEmbed, TextChannel} from "discord.js";
+import {ColorResolvable, Constants, GuildMember, EmbedBuilder, TextChannel} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import getConfigValue from "../../utils/getConfigValue";
 import GenericObject from "../../interfaces/GenericObject";
@@ -41,7 +41,7 @@ class RaidDetectionHandler extends EventHandler {
 				await modChannel.send(`**RAID DETECTION** Kicked user ${member.displayName} (${member.id}).`);
 			}
 
-			const embed = new MessageEmbed();
+			const embed = new EmbedBuilder();
 
 			embed.setTitle(":warning: Raid Detected");
 			embed.setDescription(`**We have detected a raid is currently going on and are solving the issue.**

--- a/src/interfaces/GitHubRepository.ts
+++ b/src/interfaces/GitHubRepository.ts
@@ -1,7 +1,7 @@
 interface GitHubRepository {
 	user: string;
 	repo: string;
-	description: string;
+	description?: string;
 	language: string;
 	url: string;
 	issues_and_pullrequests_count: number;

--- a/src/services/MessagePreviewService.ts
+++ b/src/services/MessagePreviewService.ts
@@ -1,4 +1,4 @@
-import {Message, TextChannel, MessageEmbed, ColorResolvable, Snowflake} from "discord.js";
+import {Message, TextChannel, EmbedBuilder, ColorResolvable, Snowflake} from "discord.js";
 import DateUtils from "../utils/DateUtils";
 import getConfigValue from "../utils/getConfigValue";
 
@@ -31,13 +31,13 @@ class MessagePreviewService {
 					}));
 
 				if (messageToPreview && !messageToPreview.author?.bot) {
-					const embed = new MessageEmbed();
+					const embed = new EmbedBuilder();
 					const parsedContent = this.escapeHyperlinks(messageToPreview.content);
 
-					embed.setAuthor(this.getAuthorName(messageToPreview), messageToPreview.author.avatarURL() || undefined, link);
+					embed.setAuthor({ name: this.getAuthorName(messageToPreview), iconURL: messageToPreview.author.avatarURL() || undefined, url: link });
 					embed.setDescription(`<#${channel.id}>\n\n${parsedContent}\n`);
-					embed.addField(getConfigValue<string>("FIELD_SPACER_CHAR"), `[View Original Message](${link})`);
-					embed.setFooter(`Message sent at ${DateUtils.formatAsText(messageToPreview.createdAt)}`);
+					embed.addFields([{ name: getConfigValue<string>("FIELD_SPACER_CHAR"), value: `[View Original Message](${link})` }]);
+					embed.setFooter({ text: `Message sent at ${DateUtils.formatAsText(messageToPreview.createdAt)}` });
 					embed.setColor(<ColorResolvable>(messageToPreview.member?.displayColor || getConfigValue<string>("MEMBER_ROLE_COLOR")));
 
 					await callingMessage.channel.send({embeds: [embed]});

--- a/src/utils/DiscordUtils.ts
+++ b/src/utils/DiscordUtils.ts
@@ -1,4 +1,4 @@
-import { BitFieldResolvable, Guild, GuildMember, Intents, IntentsString, Snowflake } from "discord.js";
+import { BitFieldResolvable, Guild, GuildMember, IntentsBitField, GatewayIntentBits, GatewayIntentsString, Snowflake } from "discord.js";
 
 class DiscordUtils {
 	static async getGuildMember(value: string, guild: Guild): Promise<GuildMember | undefined> {
@@ -27,25 +27,25 @@ class DiscordUtils {
 		return fetchedMembers.first();
 	}
 
-	static getAllIntents(): BitFieldResolvable<IntentsString, number> {
+	static getAllIntents(): BitFieldResolvable<GatewayIntentsString, number> {
 		// Stole... copied from an older version of discord.js...
 		// https://github.com/discordjs/discord.js/blob/51551f544b80d7d27ab0b315da01dfc560b2c115/src/util/Intents.js#L75
-		return Object.values(Intents.FLAGS).reduce((acc, p) => acc | p, 0);
+		return Object.values(IntentsBitField.Flags).reduce((acc, p) => acc | p as GatewayIntentBits, 0);
 	}
 
-	static getAllIntentsApartFromPresence(): BitFieldResolvable<IntentsString, number> {
+	static getAllIntentsApartFromPresence(): BitFieldResolvable<GatewayIntentsString, number> {
 		// Stole... copied from an older version of discord.js...
 		// https://github.com/discordjs/discord.js/blob/51551f544b80d7d27ab0b315da01dfc560b2c115/src/util/Intents.js#L75
-		return Object.values(Intents.FLAGS).reduce((acc, p) => {
+		return Object.values(IntentsBitField.Flags).reduce((acc, p) => {
 			// Presence updates seem to send GuildMembers without joinedAt, we assume
 			// It's being cached without this field making it null and causing issues down the line.
 			// If we do not listen on this intent, it *may* not get partially cached
 			// https://github.com/discordjs/discord.js/issues/3533
-			if (p === Intents.FLAGS.GUILD_PRESENCES) {
+			if (p === IntentsBitField.Flags.GuildPresences) {
 				return acc;
 			}
 
-			return acc | p;
+			return acc | p as GatewayIntentBits;
 		}, 0);
 	}
 }

--- a/src/utils/NumberUtils.ts
+++ b/src/utils/NumberUtils.ts
@@ -2,6 +2,10 @@ class NumberUtils {
 	static getRandomNumberInRange(min: number, max: number): number {
 		return Math.floor(Math.random() * (max - min + 1)) + min;
 	}
+
+	static hexadecimalToInteger(hex: string): number {
+		return parseInt(hex.replace("#", ""), 16);
+	}
 }
 
 export default NumberUtils;

--- a/test/MockHandler.ts
+++ b/test/MockHandler.ts
@@ -1,9 +1,9 @@
-import { Constants } from "discord.js";
+import { Events } from "discord.js";
 import EventHandler from "../src/abstracts/EventHandler";
 
 class MockHandler extends EventHandler {
 	constructor() {
-		super(Constants.Events.MESSAGE_CREATE);
+		super(Events.MessageCreate);
 	}
 
     // eslint-disable-next-line no-empty-function

--- a/test/commands/AdventOfCodeCommandTest.ts
+++ b/test/commands/AdventOfCodeCommandTest.ts
@@ -91,7 +91,7 @@ describe("AdventOfCodeCommand", () => {
 			await command.onInteract(undefined, undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const messageButton = replyStub.getCall(0).firstArg.components[0].components[0];
+			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal("Advent Of Code");
@@ -99,8 +99,8 @@ describe("AdventOfCodeCommand", () => {
 			expect(embed.fields[0].name).to.equal(`Top ${ADVENT_OF_CODE_RESULTS_PER_PAGE} in 2019`);
 			expect(embed.fields[0].value).to.equal("```java\n(Name, Stars, Points)\n 1) Lambo | 3 | 26\n```");
 			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(messageButton.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(messageButton.label).to.equal("View Leaderboard");
+			expect(button.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.label).to.equal("View Leaderboard");
 		});
 
 		it("gives an error when the wrong acces token/id is provided", async () => {
@@ -124,7 +124,7 @@ describe("AdventOfCodeCommand", () => {
 			await command.onInteract(undefined, "Lambo", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const messageButton = replyStub.getCall(0).firstArg.components[0].components[0];
+			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal("Advent Of Code");
@@ -138,8 +138,8 @@ describe("AdventOfCodeCommand", () => {
 			expect(embed.fields[3].name).to.equal("Points");
 			expect(embed.fields[3].value).to.equal("26");
 			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(messageButton.url).to.equal(`https://adventofcode.com/2021/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(messageButton.label).to.equal("View Leaderboard");
+			expect(button.url).to.equal(`https://adventofcode.com/2021/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.label).to.equal("View Leaderboard");
 		});
 
 		it("should give an error when the user doesn't exist", async () => {
@@ -178,7 +178,7 @@ describe("AdventOfCodeCommand", () => {
 			await command.onInteract(2019, undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const messageButton = replyStub.getCall(0).firstArg.components[0].components[0];
+			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(APIMock.getCall(0).args[1]).to.equal(2019);
@@ -187,8 +187,8 @@ describe("AdventOfCodeCommand", () => {
 			expect(embed.fields[0].name).to.equal(`Top ${ADVENT_OF_CODE_RESULTS_PER_PAGE} in 2019`);
 			expect(embed.fields[0].value).to.equal("```java\n(Name, Stars, Points)\n 1) Lambo | 3 | 26\n```");
 			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(messageButton.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(messageButton.label).to.equal("View Leaderboard");
+			expect(button.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.label).to.equal("View Leaderboard");
 		});
 
 		it("gives back user from requested year", async () => {
@@ -199,7 +199,7 @@ describe("AdventOfCodeCommand", () => {
 			await command.onInteract(2018, "Lambo", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const messageButton = replyStub.getCall(0).firstArg.components[0].components[0];
+			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal("Advent Of Code");
@@ -213,8 +213,8 @@ describe("AdventOfCodeCommand", () => {
 			expect(embed.fields[3].name).to.equal("Points");
 			expect(embed.fields[3].value).to.equal("26");
 			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(messageButton.url).to.equal(`https://adventofcode.com/2018/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(messageButton.label).to.equal("View Leaderboard");
+			expect(button.url).to.equal(`https://adventofcode.com/2018/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.label).to.equal("View Leaderboard");
 		});
 
 		afterEach(() => {

--- a/test/commands/AdventOfCodeCommandTest.ts
+++ b/test/commands/AdventOfCodeCommandTest.ts
@@ -6,6 +6,7 @@ import AdventOfCodeCommand from "../../src/commands/AdventOfCodeCommand";
 import AdventOfCodeService from "../../src/services/AdventOfCodeService";
 import { EMBED_COLOURS, ADVENT_OF_CODE_INVITE, ADVENT_OF_CODE_LEADERBOARD, ADVENT_OF_CODE_RESULTS_PER_PAGE } from "../../src/config.json";
 import { AOCLeaderBoard } from "../../src/interfaces/AdventOfCode";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 const AOCMockData: AOCLeaderBoard = {
 	event: "2021",
@@ -62,13 +63,13 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").throws();
 			sandbox.stub(command, "getYear").returns(2019);
 
-			await command.onInteract(interaction, 2021, "");
+			await command.onInteract(interaction, 2021, undefined);
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("Year requested not available.\nPlease query a year between 2015 and 2019");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("Year requested not available.\nPlease query a year between 2015 and 2019");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 			expect(replyStub.getCall(0).firstArg.ephemeral).to.be.true;
 		});
 
@@ -94,13 +95,13 @@ describe("AdventOfCodeCommand", () => {
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Advent Of Code");
-			expect(embed.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
-			expect(embed.fields[0].name).to.equal(`Top ${ADVENT_OF_CODE_RESULTS_PER_PAGE} in 2019`);
-			expect(embed.fields[0].value).to.equal("```java\n(Name, Stars, Points)\n 1) Lambo | 3 | 26\n```");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(button.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(button.label).to.equal("View Leaderboard");
+			expect(embed.data.title).to.equal("Advent Of Code");
+			expect(embed.data.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
+			expect(embed.data.fields[0].name).to.equal(`Top ${ADVENT_OF_CODE_RESULTS_PER_PAGE} in 2019`);
+			expect(embed.data.fields[0].value).to.equal("```java\n(Name, Stars, Points)\n 1) Lambo | 3 | 26\n```");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(button.data.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.data.label).to.equal("View Leaderboard");
 		});
 
 		it("gives an error when the wrong acces token/id is provided", async () => {
@@ -111,9 +112,9 @@ describe("AdventOfCodeCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("Could not get the leaderboard for Advent Of Code.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("Could not get the leaderboard for Advent Of Code.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 			expect(replyStub.getCall(0).firstArg.ephemeral).to.be.true;
 		});
 
@@ -127,19 +128,19 @@ describe("AdventOfCodeCommand", () => {
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Advent Of Code");
-			expect(embed.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
-			expect(embed.fields[0].name).to.equal("Scores of Lambo in 2021");
-			expect(embed.fields[0].value).to.equal("\u200B");
-			expect(embed.fields[1].name).to.equal("Position");
-			expect(embed.fields[1].value).to.equal("1");
-			expect(embed.fields[2].name).to.equal("Stars");
-			expect(embed.fields[2].value).to.equal("3");
-			expect(embed.fields[3].name).to.equal("Points");
-			expect(embed.fields[3].value).to.equal("26");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(button.url).to.equal(`https://adventofcode.com/2021/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(button.label).to.equal("View Leaderboard");
+			expect(embed.data.title).to.equal("Advent Of Code");
+			expect(embed.data.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
+			expect(embed.data.fields[0].name).to.equal("Scores of Lambo in 2021");
+			expect(embed.data.fields[0].value).to.equal("\u200B");
+			expect(embed.data.fields[1].name).to.equal("Position");
+			expect(embed.data.fields[1].value).to.equal("1");
+			expect(embed.data.fields[2].name).to.equal("Stars");
+			expect(embed.data.fields[2].value).to.equal("3");
+			expect(embed.data.fields[3].name).to.equal("Points");
+			expect(embed.data.fields[3].value).to.equal("26");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(button.data.url).to.equal(`https://adventofcode.com/2021/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.data.label).to.equal("View Leaderboard");
 		});
 
 		it("should give an error when the user doesn't exist", async () => {
@@ -150,9 +151,9 @@ describe("AdventOfCodeCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("Could not get the user requested\nPlease make sure you typed the name correctly");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("Could not get the user requested\nPlease make sure you typed the name correctly");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 			expect(replyStub.getCall(0).firstArg.ephemeral).to.be.true;
 		});
 
@@ -164,9 +165,9 @@ describe("AdventOfCodeCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("Could not get the statistics for Advent Of Code.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("Could not get the statistics for Advent Of Code.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 			expect(replyStub.getCall(0).firstArg.ephemeral).to.be.true;
 		});
 
@@ -182,13 +183,13 @@ describe("AdventOfCodeCommand", () => {
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(APIMock.getCall(0).args[1]).to.equal(2019);
-			expect(embed.title).to.equal("Advent Of Code");
-			expect(embed.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
-			expect(embed.fields[0].name).to.equal(`Top ${ADVENT_OF_CODE_RESULTS_PER_PAGE} in 2019`);
-			expect(embed.fields[0].value).to.equal("```java\n(Name, Stars, Points)\n 1) Lambo | 3 | 26\n```");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(button.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(button.label).to.equal("View Leaderboard");
+			expect(embed.data.title).to.equal("Advent Of Code");
+			expect(embed.data.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
+			expect(embed.data.fields[0].name).to.equal(`Top ${ADVENT_OF_CODE_RESULTS_PER_PAGE} in 2019`);
+			expect(embed.data.fields[0].value).to.equal("```java\n(Name, Stars, Points)\n 1) Lambo | 3 | 26\n```");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(button.data.url).to.equal(`https://adventofcode.com/2019/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.data.label).to.equal("View Leaderboard");
 		});
 
 		it("gives back user from requested year", async () => {
@@ -202,19 +203,19 @@ describe("AdventOfCodeCommand", () => {
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Advent Of Code");
-			expect(embed.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
-			expect(embed.fields[0].name).to.equal("Scores of Lambo in 2018");
-			expect(embed.fields[0].value).to.equal("\u200B");
-			expect(embed.fields[1].name).to.equal("Position");
-			expect(embed.fields[1].value).to.equal("1");
-			expect(embed.fields[2].name).to.equal("Stars");
-			expect(embed.fields[2].value).to.equal("3");
-			expect(embed.fields[3].name).to.equal("Points");
-			expect(embed.fields[3].value).to.equal("26");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(button.url).to.equal(`https://adventofcode.com/2018/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
-			expect(button.label).to.equal("View Leaderboard");
+			expect(embed.data.title).to.equal("Advent Of Code");
+			expect(embed.data.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
+			expect(embed.data.fields[0].name).to.equal("Scores of Lambo in 2018");
+			expect(embed.data.fields[0].value).to.equal("\u200B");
+			expect(embed.data.fields[1].name).to.equal("Position");
+			expect(embed.data.fields[1].value).to.equal("1");
+			expect(embed.data.fields[2].name).to.equal("Stars");
+			expect(embed.data.fields[2].value).to.equal("3");
+			expect(embed.data.fields[3].name).to.equal("Points");
+			expect(embed.data.fields[3].value).to.equal("26");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(button.data.url).to.equal(`https://adventofcode.com/2018/leaderboard/private/view/${ADVENT_OF_CODE_LEADERBOARD}`);
+			expect(button.data.label).to.equal("View Leaderboard");
 		});
 
 		afterEach(() => {

--- a/test/commands/AdventOfCodeCommandTest.ts
+++ b/test/commands/AdventOfCodeCommandTest.ts
@@ -53,7 +53,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getSortedPlayerList");
 			sandbox.stub(AOC, "getSinglePlayer");
 
-			await command.onInteract(2021, "Lambo", interaction);
+			await command.onInteract(interaction, 2021, "Lambo");
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
@@ -62,7 +62,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").throws();
 			sandbox.stub(command, "getYear").returns(2019);
 
-			await command.onInteract(2021, undefined, interaction);
+			await command.onInteract(interaction, 2021, "");
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
@@ -77,7 +77,7 @@ describe("AdventOfCodeCommand", () => {
 
 			sandbox.stub(command, "getYear").returns(2020);
 
-			await command.onInteract(2018, undefined, interaction);
+			await command.onInteract(interaction, 2018, undefined);
 
 			expect(serviceMock.calledOnce).to.be.true;
 			expect(serviceMock.getCall(0).args[1]).to.equal(2018);
@@ -88,7 +88,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").resolves(AOCMockData);
 			sandbox.stub(command, "getYear").returns(2019);
 
-			await command.onInteract(undefined, undefined, interaction);
+			await command.onInteract(interaction, undefined, undefined);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
@@ -106,7 +106,7 @@ describe("AdventOfCodeCommand", () => {
 		it("gives an error when the wrong acces token/id is provided", async () => {
 			sandbox.stub(AOC, "getLeaderBoard").throws();
 
-			await command.onInteract(undefined, undefined, interaction);
+			await command.onInteract(interaction, undefined, undefined);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -121,7 +121,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").resolves(AOCMockData);
 			sandbox.stub(command, "getYear").returns(2021);
 
-			await command.onInteract(undefined, "Lambo", interaction);
+			await command.onInteract(interaction, undefined, "Lambo");
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
@@ -145,7 +145,7 @@ describe("AdventOfCodeCommand", () => {
 		it("should give an error when the user doesn't exist", async () => {
 			sandbox.stub(AOC, "getLeaderBoard").resolves(AOCMockData);
 
-			await command.onInteract(undefined, "Bob", interaction);
+			await command.onInteract(interaction, undefined, "Bob");
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -159,7 +159,7 @@ describe("AdventOfCodeCommand", () => {
 		it("gives an error when the name parameter is given but wrong acces token/id is provided", async () => {
 			sandbox.stub(AOC, "getSinglePlayer").throws();
 
-			await command.onInteract(undefined, "Lambo", interaction);
+			await command.onInteract(interaction, undefined, "Lambo");
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -175,7 +175,7 @@ describe("AdventOfCodeCommand", () => {
 
 			sandbox.stub(command, "getYear").returns(2020);
 
-			await command.onInteract(2019, undefined, interaction);
+			await command.onInteract(interaction, 2019, undefined);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
@@ -196,7 +196,7 @@ describe("AdventOfCodeCommand", () => {
 
 			sandbox.stub(command, "getYear").returns(2021);
 
-			await command.onInteract(2018, "Lambo", interaction);
+			await command.onInteract(interaction, 2018, "Lambo");
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];

--- a/test/commands/AdventOfCodeCommandTest.ts
+++ b/test/commands/AdventOfCodeCommandTest.ts
@@ -54,7 +54,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getSortedPlayerList");
 			sandbox.stub(AOC, "getSinglePlayer");
 
-			await command.onInteract(interaction, 2021, "Lambo");
+			await command.onInteract(2021, "Lambo", interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
@@ -63,7 +63,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").throws();
 			sandbox.stub(command, "getYear").returns(2019);
 
-			await command.onInteract(interaction, 2021, undefined);
+			await command.onInteract(2021, undefined, interaction);
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
@@ -78,7 +78,7 @@ describe("AdventOfCodeCommand", () => {
 
 			sandbox.stub(command, "getYear").returns(2020);
 
-			await command.onInteract(interaction, 2018, undefined);
+			await command.onInteract(2018, undefined, interaction);
 
 			expect(serviceMock.calledOnce).to.be.true;
 			expect(serviceMock.getCall(0).args[1]).to.equal(2018);
@@ -89,7 +89,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").resolves(AOCMockData);
 			sandbox.stub(command, "getYear").returns(2019);
 
-			await command.onInteract(interaction, undefined, undefined);
+			await command.onInteract(undefined, undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
@@ -107,7 +107,7 @@ describe("AdventOfCodeCommand", () => {
 		it("gives an error when the wrong acces token/id is provided", async () => {
 			sandbox.stub(AOC, "getLeaderBoard").throws();
 
-			await command.onInteract(interaction, undefined, undefined);
+			await command.onInteract(undefined, undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -122,7 +122,7 @@ describe("AdventOfCodeCommand", () => {
 			sandbox.stub(AOC, "getLeaderBoard").resolves(AOCMockData);
 			sandbox.stub(command, "getYear").returns(2021);
 
-			await command.onInteract(interaction, undefined, "Lambo");
+			await command.onInteract(undefined, "Lambo", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
@@ -146,7 +146,7 @@ describe("AdventOfCodeCommand", () => {
 		it("should give an error when the user doesn't exist", async () => {
 			sandbox.stub(AOC, "getLeaderBoard").resolves(AOCMockData);
 
-			await command.onInteract(interaction, undefined, "Bob");
+			await command.onInteract(undefined, "Bob", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -160,7 +160,7 @@ describe("AdventOfCodeCommand", () => {
 		it("gives an error when the name parameter is given but wrong acces token/id is provided", async () => {
 			sandbox.stub(AOC, "getSinglePlayer").throws();
 
-			await command.onInteract(interaction, undefined, "Lambo");
+			await command.onInteract(undefined, "Lambo", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -176,7 +176,7 @@ describe("AdventOfCodeCommand", () => {
 
 			sandbox.stub(command, "getYear").returns(2020);
 
-			await command.onInteract(interaction, 2019, undefined);
+			await command.onInteract(2019, undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
@@ -197,12 +197,13 @@ describe("AdventOfCodeCommand", () => {
 
 			sandbox.stub(command, "getYear").returns(2021);
 
-			await command.onInteract(interaction, 2018, "Lambo");
+			await command.onInteract(2018, "Lambo", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const button = replyStub.getCall(0).firstArg.components[0].components[0];
 
 			expect(replyStub.calledOnce).to.be.true;
+			expect(APIMock.getCall(0).args[1]).to.equal(2018);
 			expect(embed.data.title).to.equal("Advent Of Code");
 			expect(embed.data.description).to.equal(`Invite Code: \`${ADVENT_OF_CODE_INVITE}\``);
 			expect(embed.data.fields[0].name).to.equal("Scores of Lambo in 2018");

--- a/test/commands/CodeblockCommandTest.ts
+++ b/test/commands/CodeblockCommandTest.ts
@@ -1,5 +1,6 @@
 import { createSandbox, SinonSandbox } from "sinon";
 import { expect } from "chai";
+import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import CodeblockCommand from "../../src/commands/CodeblockCommand";
 import { EMBED_COLOURS } from "../../src/config.json";
@@ -8,28 +9,27 @@ describe("CodeblockCommand", () => {
 	describe("onInteract()", () => {
 		let sandbox: SinonSandbox;
 		let command: CodeblockCommand;
+		let interaction: any;
+		let replyStub: sinon.SinonStub<any[], any>;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			command = new CodeblockCommand();
+			replyStub = sandbox.stub().resolves();
+			interaction = {
+				reply: replyStub,
+				user: BaseMocks.getGuildMember()
+			};
 		});
 
 		it("sends a message to the channel", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract({
-				reply: replyStub
-			});
+			await command.onInteract(interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("states how to create a codeblock", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract({
-				reply: replyStub
-			});
+			await command.onInteract(interaction);
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = replyStub.getCall(0).firstArg.embeds[0];

--- a/test/commands/CodeblockCommandTest.ts
+++ b/test/commands/CodeblockCommandTest.ts
@@ -4,6 +4,7 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import CodeblockCommand from "../../src/commands/CodeblockCommand";
 import { EMBED_COLOURS } from "../../src/config.json";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("CodeblockCommand", () => {
 	describe("onInteract()", () => {
@@ -35,14 +36,14 @@ describe("CodeblockCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Codeblock Tutorial");
-			expect(embed.description).to.equal("Please use codeblocks when sending code.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
+			expect(embed.data.title).to.equal("Codeblock Tutorial");
+			expect(embed.data.description).to.equal("Please use codeblocks when sending code.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
 
-			expect(embed.fields[0].name).to.equal("Sending lots of code?");
-			expect(embed.fields[0].value).to.equal("Consider using a [GitHub Gist](http://gist.github.com).");
+			expect(embed.data.fields[0].name).to.equal("Sending lots of code?");
+			expect(embed.data.fields[0].value).to.equal("Consider using a [GitHub Gist](http://gist.github.com).");
 
-			expect(embed.image.url).to.equal("attachment://codeblock-tutorial.png");
+			expect(embed.data.image.url).to.equal("attachment://codeblock-tutorial.png");
 		});
 
 		afterEach(() => {

--- a/test/commands/GitHubCommandTest.ts
+++ b/test/commands/GitHubCommandTest.ts
@@ -35,8 +35,8 @@ describe("GitHubCommand", () => {
 		});
 
 		it("states it had a problem with the request to GitHub", async () => {
-			sandbox.stub(gitHub, "getRepository").resolves(null);
-			sandbox.stub(gitHub, "getPullRequest").resolves(null);
+			sandbox.stub(gitHub, "getRepository").resolves(undefined);
+			sandbox.stub(gitHub, "getPullRequest").resolves(undefined);
 
 			await command.onInteract("thisuserdoesnotexist", "thisrepodoesnotexist", interaction);
 
@@ -99,7 +99,7 @@ describe("GitHubCommand", () => {
 			sandbox.stub(gitHub, "getRepository").resolves({
 				user: "user",
 				repo: "repo",
-				description: null,
+				description: undefined,
 				language: "TypeScript",
 				url: "https://github.com/codesupport/discord-bot",
 				issues_and_pullrequests_count: 3,

--- a/test/commands/GitHubCommandTest.ts
+++ b/test/commands/GitHubCommandTest.ts
@@ -5,6 +5,7 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import GitHubCommand from "../../src/commands/GitHubCommand";
 import GitHubService from "../../src/services/GitHubService";
 import { EMBED_COLOURS } from "../../src/config.json";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("GitHubCommand", () => {
 	describe("onInteract()", () => {
@@ -44,11 +45,11 @@ describe("GitHubCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("There was a problem with the request to GitHub.");
-			expect(embed.fields[0].name).to.equal("Correct Usage");
-			expect(embed.fields[0].value).to.equal("?github <username>/<repository>");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("There was a problem with the request to GitHub.");
+			expect(embed.data.fields[0].name).to.equal("Correct Usage");
+			expect(embed.data.fields[0].value).to.equal("?github <username>/<repository>");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 		});
 
 		it("states the result from the github service", async () => {
@@ -78,21 +79,21 @@ describe("GitHubCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("GitHub Repository: user/repo");
-			expect(embed.description).to.equal("This is the description\n\n[View on GitHub](https://github.com/codesupport/discord-bot)");
-			expect(embed.fields[0].name).to.equal("Language");
-			expect(embed.fields[0].value).to.equal("TypeScript");
-			expect(embed.fields[1].name).to.equal("Open issues");
-			expect(embed.fields[1].value).to.equal("2");
-			expect(embed.fields[2].name).to.equal("Open Pull Requests");
-			expect(embed.fields[2].value).to.equal("1");
-			expect(embed.fields[3].name).to.equal("Forks");
-			expect(embed.fields[3].value).to.equal("5");
-			expect(embed.fields[4].name).to.equal("Stars");
-			expect(embed.fields[4].value).to.equal("10");
-			expect(embed.fields[5].name).to.equal("Watchers");
-			expect(embed.fields[5].value).to.equal("3");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
+			expect(embed.data.title).to.equal("GitHub Repository: user/repo");
+			expect(embed.data.description).to.equal("This is the description\n\n[View on GitHub](https://github.com/codesupport/discord-bot)");
+			expect(embed.data.fields[0].name).to.equal("Language");
+			expect(embed.data.fields[0].value).to.equal("TypeScript");
+			expect(embed.data.fields[1].name).to.equal("Open Issues");
+			expect(embed.data.fields[1].value).to.equal("2");
+			expect(embed.data.fields[2].name).to.equal("Open Pull Requests");
+			expect(embed.data.fields[2].value).to.equal("1");
+			expect(embed.data.fields[3].name).to.equal("Forks");
+			expect(embed.data.fields[3].value).to.equal("5");
+			expect(embed.data.fields[4].name).to.equal("Stars");
+			expect(embed.data.fields[4].value).to.equal("10");
+			expect(embed.data.fields[5].name).to.equal("Watchers");
+			expect(embed.data.fields[5].value).to.equal("3");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
 		});
 
 		it("states the result from the github service with an empty repo description", async () => {
@@ -122,7 +123,7 @@ describe("GitHubCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.description).to.equal("[View on GitHub](https://github.com/codesupport/discord-bot)");
+			expect(embed.data.description).to.equal("[View on GitHub](https://github.com/codesupport/discord-bot)");
 		});
 
 		afterEach(() => {

--- a/test/commands/HiringLookingCommandTest.ts
+++ b/test/commands/HiringLookingCommandTest.ts
@@ -6,6 +6,7 @@ import { EMBED_COLOURS } from "../../src/config.json";
 import HiringLookingCommand from "../../src/commands/HiringLookingCommand";
 import getConfigValue from "../../src/utils/getConfigValue";
 import GenericObject from "../../src/interfaces/GenericObject";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("HiringLookingCommand", () => {
 	describe("onInteract()", () => {
@@ -37,22 +38,22 @@ describe("HiringLookingCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Hiring or Looking Posts");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
+			expect(embed.data.title).to.equal("Hiring or Looking Posts");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
 
 			// The indentation on these is a mess due to the test comparing white space.
-			expect(embed.description).to.equal(`
+			expect(embed.data.description).to.equal(`
 			CodeSupport offers a free to use hiring or looking section.\n
 			Here you can find people to work for you and offer your services,
 			as long as it fits in with the rules. If you get scammed in hiring or looking there is
 			nothing we can do, however, we do ask that you let a moderator know.
 		`);
-			expect(embed.fields[0].name).to.equal("Payment");
-			expect(embed.fields[0].value).to.equal("If you are trying to hire people for a project, and that project is not open source, your post must state how much you will pay them (or a percentage of profits they will receive).");
-			expect(embed.fields[1].name).to.equal("Post Frequency");
-			expect(embed.fields[1].value).to.equal(`Please only post in <#${getConfigValue<GenericObject<string>>("BOTLESS_CHANNELS").HIRING_OR_LOOKING}> once per week to keep the channel clean and fair. Posting multiple times per week will lead to your access to the channel being revoked.`);
-			expect(embed.fields[2].name).to.equal("Example Post");
-			expect(embed.fields[2].value).to.equal(`
+			expect(embed.data.fields[0].name).to.equal("Payment");
+			expect(embed.data.fields[0].value).to.equal("If you are trying to hire people for a project, and that project is not open source, your post must state how much you will pay them (or a percentage of profits they will receive).");
+			expect(embed.data.fields[1].name).to.equal("Post Frequency");
+			expect(embed.data.fields[1].value).to.equal(`Please only post in <#${getConfigValue<GenericObject<string>>("BOTLESS_CHANNELS").HIRING_OR_LOOKING}> once per week to keep the channel clean and fair. Posting multiple times per week will lead to your access to the channel being revoked.`);
+			expect(embed.data.fields[2].name).to.equal("Example Post");
+			expect(embed.data.fields[2].value).to.equal(`
 			Please use the example below as a template to base your post on.\n
 			\`\`\`
 [HIRING]

--- a/test/commands/HiringLookingCommandTest.ts
+++ b/test/commands/HiringLookingCommandTest.ts
@@ -1,5 +1,6 @@
 import { createSandbox, SinonSandbox } from "sinon";
 import { expect } from "chai";
+import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import { EMBED_COLOURS } from "../../src/config.json";
 import HiringLookingCommand from "../../src/commands/HiringLookingCommand";
@@ -10,28 +11,27 @@ describe("HiringLookingCommand", () => {
 	describe("onInteract()", () => {
 		let sandbox: SinonSandbox;
 		let command: HiringLookingCommand;
+		let replyStub: sinon.SinonStub<any[], any>;
+		let interaction: any;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			command = new HiringLookingCommand();
+			replyStub = sandbox.stub().resolves();
+			interaction = {
+				reply: replyStub,
+				user: BaseMocks.getGuildMember()
+			};
 		});
 
 		it("sends a message to the channel", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract({
-				reply: replyStub
-			});
+			await command.onInteract(interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("states how to format a post", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract({
-				reply: replyStub
-			});
+			await command.onInteract(interaction);
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = replyStub.getCall(0).firstArg.embeds[0];

--- a/test/commands/InspectCommandTest.ts
+++ b/test/commands/InspectCommandTest.ts
@@ -1,6 +1,6 @@
 import { createSandbox, SinonSandbox } from "sinon";
 import { expect } from "chai";
-import { Collection, EmbedField, GuildMember, GuildMemberRoleManager, Role, Formatters } from "discord.js";
+import { Collection, EmbedField, GuildMember, GuildMemberRoleManager, Role, time, TimestampStyles } from "discord.js";
 import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import InspectCommand from "../../src/commands/InspectCommand";
@@ -52,8 +52,8 @@ describe("InspectCommand", () => {
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
-			const relativeTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
+			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);
+			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
@@ -82,8 +82,8 @@ describe("InspectCommand", () => {
 			await command.onInteract(undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
-			const relativeTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
+			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);
+			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
@@ -106,8 +106,8 @@ describe("InspectCommand", () => {
 			await command.onInteract(member, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
-			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);
-			const relativeTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.RelativeTime);
+			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);
+			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
 			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);

--- a/test/commands/InspectCommandTest.ts
+++ b/test/commands/InspectCommandTest.ts
@@ -5,6 +5,7 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import InspectCommand from "../../src/commands/InspectCommand";
 import DiscordUtils from "../../src/utils/DiscordUtils";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
 	"id": "12345",
@@ -34,7 +35,7 @@ describe("InspectCommand", () => {
 		});
 
 		it("sends a message to the channel", async () => {
-			await command.onInteract(BaseMocks.getGuildMember(), interaction);
+			await command.onInteract(interaction, BaseMocks.getGuildMember());
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
@@ -48,7 +49,7 @@ describe("InspectCommand", () => {
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
 
 			// @ts-ignore
-			await command.onInteract("123321hehexd", interaction);
+			await command.onInteract(interaction, member);
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
@@ -56,18 +57,18 @@ describe("InspectCommand", () => {
 			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
-			expect(embed.fields[0].name).to.equal("User ID");
-			expect(embed.fields[0].value).to.equal(member.user.id);
-			expect(embed.fields[1].name).to.equal("Username");
-			expect(embed.fields[1].value).to.equal(member.user.tag);
-			expect(embed.fields[2].name).to.equal("Nickname");
-			expect(embed.fields[2].value).to.equal("my name");
-			expect(embed.fields[3].name).to.equal("Joined At");
-			expect(embed.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
-			expect(embed.fields[4].name).to.equal("Roles");
-			expect(embed.fields[4].value).to.equal(" <@&12345>");
-			expect(embed.hexColor).to.equal(member.displayColor);
+			expect(embed.data.title).to.equal(`Inspecting ${member.user.tag}`);
+			expect(embed.data.fields[0].name).to.equal("User ID");
+			expect(embed.data.fields[0].value).to.equal(member.user.id);
+			expect(embed.data.fields[1].name).to.equal("Username");
+			expect(embed.data.fields[1].value).to.equal(member.user.tag);
+			expect(embed.data.fields[2].name).to.equal("Nickname");
+			expect(embed.data.fields[2].value).to.equal("my name");
+			expect(embed.data.fields[3].name).to.equal("Joined At");
+			expect(embed.data.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
+			expect(embed.data.fields[4].name).to.equal("Roles");
+			expect(embed.data.fields[4].value).to.equal(" <@&12345>");
+			expect(embed.data.color).to.equal(member.displayColor);
 		});
 
 		it("sends a message with information if no argument was provided", async () => {
@@ -79,20 +80,20 @@ describe("InspectCommand", () => {
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
 
 			// @ts-ignore
-			await command.onInteract(undefined, interaction);
+			await command.onInteract(interaction, member);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);
 			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
-			expect(embed.fields.find((field: EmbedField) => field.name === "User ID")?.value).to.equal(member.user.id);
-			expect(embed.fields.find((field: EmbedField) => field.name === "Username")?.value).to.equal(member.user.tag);
-			expect(embed.fields.find((field: EmbedField) => field.name === "Nickname")?.value ?? null).to.equal(member?.nickname);
-			expect(embed.fields.find((field: EmbedField) => field.name === "Joined At")?.value ?? null).to.equal(`${shortDateTime} ${relativeTime}`);
-			expect(embed.fields.find((field: EmbedField) => field.name === "Roles")?.value).to.equal(" <@&12345>");
-			expect(embed.hexColor).to.equal(member.displayColor);
+			expect(embed.data.title).to.equal(`Inspecting ${member.user.tag}`);
+			expect(embed.data.fields.find((field: EmbedField) => field.name === "User ID")?.value).to.equal(member.user.id);
+			expect(embed.data.fields.find((field: EmbedField) => field.name === "Username")?.value).to.equal(member.user.tag);
+			expect(embed.data.fields.find((field: EmbedField) => field.name === "Nickname")?.value ?? null).to.equal(member?.nickname);
+			expect(embed.data.fields.find((field: EmbedField) => field.name === "Joined At")?.value ?? null).to.equal(`${shortDateTime} ${relativeTime}`);
+			expect(embed.data.fields.find((field: EmbedField) => field.name === "Roles")?.value).to.equal(" <@&12345>");
+			expect(embed.data.color).to.equal(member.displayColor);
 		});
 
 		it("handles role field correctly if member has no role", async () => {
@@ -103,25 +104,25 @@ describe("InspectCommand", () => {
 
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => new Collection([]));
 
-			await command.onInteract(member, interaction);
+			await command.onInteract(interaction, member);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);
 			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal(`Inspecting ${member.user.tag}`);
-			expect(embed.fields[0].name).to.equal("User ID");
-			expect(embed.fields[0].value).to.equal(member.user.id);
-			expect(embed.fields[1].name).to.equal("Username");
-			expect(embed.fields[1].value).to.equal(member.user.tag);
-			expect(embed.fields[2].name).to.equal("Nickname");
-			expect(embed.fields[2].value).to.equal("my name");
-			expect(embed.fields[3].name).to.equal("Joined At");
-			expect(embed.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
-			expect(embed.fields[4].name).to.equal("Roles");
-			expect(embed.fields[4].value).to.equal("No roles");
-			expect(embed.hexColor).to.equal("#1555b7");
+			expect(embed.data.title).to.equal(`Inspecting ${member.user.tag}`);
+			expect(embed.data.fields[0].name).to.equal("User ID");
+			expect(embed.data.fields[0].value).to.equal(member.user.id);
+			expect(embed.data.fields[1].name).to.equal("Username");
+			expect(embed.data.fields[1].value).to.equal(member.user.tag);
+			expect(embed.data.fields[2].name).to.equal("Nickname");
+			expect(embed.data.fields[2].value).to.equal("my name");
+			expect(embed.data.fields[3].name).to.equal("Joined At");
+			expect(embed.data.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
+			expect(embed.data.fields[4].name).to.equal("Roles");
+			expect(embed.data.fields[4].value).to.equal("No roles");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger("#1555b7"));
 		});
 
 		afterEach(() => {

--- a/test/commands/InspectCommandTest.ts
+++ b/test/commands/InspectCommandTest.ts
@@ -103,7 +103,7 @@ describe("InspectCommand", () => {
 
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => new Collection([]));
 
-			await command.onInteract(member.user.username, interaction);
+			await command.onInteract(member, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const shortDateTime = Formatters.time(member?.joinedAt!, Formatters.TimestampStyles.ShortDateTime);

--- a/test/commands/InspectCommandTest.ts
+++ b/test/commands/InspectCommandTest.ts
@@ -35,7 +35,7 @@ describe("InspectCommand", () => {
 		});
 
 		it("sends a message to the channel", async () => {
-			await command.onInteract(interaction, BaseMocks.getGuildMember());
+			await command.onInteract(BaseMocks.getGuildMember(), interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
@@ -49,7 +49,7 @@ describe("InspectCommand", () => {
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
 
 			// @ts-ignore
-			await command.onInteract(interaction, member);
+			await command.onInteract(member, interaction);
 
 			// @ts-ignore - firstArg does not live on getCall()
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
@@ -80,7 +80,7 @@ describe("InspectCommand", () => {
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
 
 			// @ts-ignore
-			await command.onInteract(interaction, member);
+			await command.onInteract(member, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);
@@ -104,7 +104,7 @@ describe("InspectCommand", () => {
 
 			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => new Collection([]));
 
-			await command.onInteract(interaction, member);
+			await command.onInteract(member, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 			const shortDateTime = time(member?.joinedAt!, TimestampStyles.ShortDateTime);

--- a/test/commands/InspectCommandTest.ts
+++ b/test/commands/InspectCommandTest.ts
@@ -7,15 +7,34 @@ import InspectCommand from "../../src/commands/InspectCommand";
 import DiscordUtils from "../../src/utils/DiscordUtils";
 import NumberUtils from "../../src/utils/NumberUtils";
 
-const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
-	"id": "12345",
-	"name": "TestRole",
-	"permissions": 1
-}, BaseMocks.getGuild())], [BaseMocks.getGuild().id, new Role(BaseMocks.getClient(), {
-	"id": BaseMocks.getGuild().id,
-	"name": "@everyone",
-	"permissions": 1
-}, BaseMocks.getGuild())]]);
+const roleCollection = new Collection([
+	[
+		"12345",
+		Reflect.construct(Role,
+			[
+				BaseMocks.getClient(),
+				{
+					"id": "12345",
+					"name": "TestRole",
+					"permissions": 1
+				},
+				BaseMocks.getGuild()
+			])
+	],
+	[
+		BaseMocks.getGuild().id,
+		Reflect.construct(Role,
+			[
+				BaseMocks.getClient(),
+				{
+					"id": BaseMocks.getGuild().id,
+					"name": "@everyone",
+					"permissions": 1
+				},
+				BaseMocks.getGuild()
+			])
+	]
+]);
 
 describe("InspectCommand", () => {
 	describe("onInteract()", () => {
@@ -43,10 +62,9 @@ describe("InspectCommand", () => {
 		it("sends a message with information if an argument was provided", async () => {
 			const member = BaseMocks.getGuildMember();
 
-			sandbox.stub(GuildMember.prototype, "displayColor").get(() => "#ffffff");
+			sandbox.stub(member, "displayColor").get(() => NumberUtils.hexadecimalToInteger("#ffffff"));
 			sandbox.stub(DiscordUtils, "getGuildMember").resolves(member);
-
-			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
+			sandbox.stub(member, "roles").get(() => ({ cache: roleCollection }));
 
 			// @ts-ignore
 			await command.onInteract(member, interaction);
@@ -74,10 +92,9 @@ describe("InspectCommand", () => {
 		it("sends a message with information if no argument was provided", async () => {
 			const member = BaseMocks.getGuildMember();
 
-			sandbox.stub(GuildMember.prototype, "displayColor").get(() => "#ffffff");
+			sandbox.stub(member, "displayColor").get(() => NumberUtils.hexadecimalToInteger("#ffffff"));
 			sandbox.stub(DiscordUtils, "getGuildMember").resolves(member);
-
-			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
+			sandbox.stub(member, "roles").get(() => ({ cache: roleCollection }));
 
 			// @ts-ignore
 			await command.onInteract(member, interaction);
@@ -99,10 +116,9 @@ describe("InspectCommand", () => {
 		it("handles role field correctly if member has no role", async () => {
 			const member = BaseMocks.getGuildMember();
 
-			sandbox.stub(GuildMember.prototype, "displayColor").get(() => "#1555b7");
+			sandbox.stub(member, "displayColor").get(() => NumberUtils.hexadecimalToInteger("#1555b7"));
 			sandbox.stub(DiscordUtils, "getGuildMember").resolves(member);
-
-			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => new Collection([]));
+			sandbox.stub(member, "roles").get(() => ({ cache: new Collection([]) }));
 
 			await command.onInteract(member, interaction);
 
@@ -122,7 +138,7 @@ describe("InspectCommand", () => {
 			expect(embed.data.fields[3].value).to.equal(`${shortDateTime} ${relativeTime}`);
 			expect(embed.data.fields[4].name).to.equal("Roles");
 			expect(embed.data.fields[4].value).to.equal("No roles");
-			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger("#1555b7"));
+			expect(embed.data.color).to.equal(member.displayColor);
 		});
 
 		afterEach(() => {

--- a/test/commands/IssuesCommandTest.ts
+++ b/test/commands/IssuesCommandTest.ts
@@ -5,6 +5,7 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import IssuesCommand from "../../src/commands/IssuesCommand";
 import GitHubService from "../../src/services/GitHubService";
 import { EMBED_COLOURS } from "../../src/config.json";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("IssuesCommand", () => {
 	describe("onInteract()", () => {
@@ -43,11 +44,11 @@ describe("IssuesCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("There was a problem with the request to GitHub.");
-			expect(embed.fields[0].name).to.equal("Correct Usage");
-			expect(embed.fields[0].value).to.equal("/issues <username>/<repository>");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("There was a problem with the request to GitHub.");
+			expect(embed.data.fields[0].name).to.equal("Correct Usage");
+			expect(embed.data.fields[0].value).to.equal("/issues <username>/<repository>");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 		});
 
 		it("states no issues have been found", async () => {
@@ -72,9 +73,9 @@ describe("IssuesCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("No Issues found");
-			expect(embed.description).to.equal("This repository has no issues. [Create one](https://github.com/codesupport/discord-bot/issues/new)");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
+			expect(embed.data.title).to.equal("No Issues found");
+			expect(embed.data.description).to.equal("This repository has no issues. [Create one](https://github.com/codesupport/discord-bot/issues/new)");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
 		});
 
 		it("states the result from the github service", async () => {
@@ -106,11 +107,11 @@ describe("IssuesCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("GitHub Issues: user/repo");
-			expect(embed.description).to.equal("This is the description\n\n[View Issues on GitHub](https://github.com/codesupport/discord-bot/issues) - [Create An Issue](https://github.com/codesupport/discord-bot/issues/new)");
-			expect(embed.fields[0].name).to.equal("#69 - This is the title");
-			expect(embed.fields[0].value).to.equal("View on [GitHub](https://github.com/codesupport/discord-bot/issues/69) - Today by [user](https://github.com/user)");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
+			expect(embed.data.title).to.equal("GitHub Issues: user/repo");
+			expect(embed.data.description).to.equal("This is the description\n\n[View Issues on GitHub](https://github.com/codesupport/discord-bot/issues) - [Create An Issue](https://github.com/codesupport/discord-bot/issues/new)");
+			expect(embed.data.fields[0].name).to.equal("#69 - This is the title");
+			expect(embed.data.fields[0].value).to.equal("View on [GitHub](https://github.com/codesupport/discord-bot/issues/69) - Today by [user](https://github.com/user)");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
 		});
 
 		afterEach(() => {

--- a/test/commands/IssuesCommandTest.ts
+++ b/test/commands/IssuesCommandTest.ts
@@ -35,8 +35,8 @@ describe("IssuesCommand", () => {
 		});
 
 		it("states it had a problem with the request to GitHub", async () => {
-			sandbox.stub(gitHub, "getIssues").resolves(null);
-			sandbox.stub(gitHub, "getRepository").resolves(null);
+			sandbox.stub(gitHub, "getIssues").resolves(undefined);
+			sandbox.stub(gitHub, "getRepository").resolves(undefined);
 
 			await command.onInteract("thisuserdoesnotexist", "thisrepodoesnotexist", interaction);
 

--- a/test/commands/NPMCommandTest.ts
+++ b/test/commands/NPMCommandTest.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import NPMCommand from "../../src/commands/NPMCommand";
 import { EMBED_COLOURS } from "../../src/config.json";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("NPMCommand", () => {
 	describe("run()", () => {
@@ -38,9 +39,9 @@ describe("NPMCommand", () => {
 			const embed = replyStub.getCall(0).lastArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("That is not a valid NPM package.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("That is not a valid NPM package.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 		});
 
 		it("sends a message with the package URL if you provide a valid package", async () => {

--- a/test/commands/ProjectCommandTest.ts
+++ b/test/commands/ProjectCommandTest.ts
@@ -3,6 +3,7 @@ import { createSandbox, SinonSandbox } from "sinon";
 import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import { EMBED_COLOURS } from "../../src/config.json";
 import ProjectCommand from "../../src/commands/ProjectCommand";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("ProjectCommand", () => {
 	describe("onInteract()", () => {
@@ -57,9 +58,9 @@ describe("ProjectCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("Could not find a project result for the given query.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("Could not find a project result for the given query.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 		});
 
 		it("should assign the correct colors for difficulty grade if difficulty grade is specified", async () => {
@@ -73,10 +74,10 @@ describe("ProjectCommand", () => {
 			const thirdCall = replyStub.getCall(2).firstArg.embeds[0];
 			const lastCall = replyStub.getCall(3).firstArg.embeds[0];
 
-			expect(firstCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-			expect(secondCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-			expect(thirdCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
-			expect(lastCall.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
+			expect(firstCall.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
+			expect(secondCall.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
+			expect(thirdCall.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
+			expect(lastCall.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
 		});
 
 		it("should filter out too long descriptions out of the resultset", async () => {
@@ -85,9 +86,9 @@ describe("ProjectCommand", () => {
 			const firstCall = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(firstCall.title).to.equal("Error");
-			expect(firstCall.description).to.equal("Could not find a project result for the given query.");
-			expect(firstCall.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(firstCall.data.title).to.equal("Error");
+			expect(firstCall.data.description).to.equal("Could not find a project result for the given query.");
+			expect(firstCall.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 		});
 
 		afterEach(() => {

--- a/test/commands/ResourcesCommandTest.ts
+++ b/test/commands/ResourcesCommandTest.ts
@@ -23,13 +23,13 @@ describe("ResourcesCommand", () => {
 		});
 
 		it("sends a message to the channel", async () => {
-			await command.onInteract(interaction, undefined);
+			await command.onInteract(undefined, interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("sends the link to resources page if no argument is given", async () => {
-			await command.onInteract(interaction, undefined);
+			await command.onInteract(undefined, interaction);
 
 			const { content: url } = replyStub.firstCall.lastArg;
 
@@ -38,7 +38,7 @@ describe("ResourcesCommand", () => {
 		});
 
 		it("sends link to the category page if an argument is given", async () => {
-			await command.onInteract(interaction, "javascript");
+			await command.onInteract("javascript", interaction);
 
 			const { content: url } = replyStub.firstCall.lastArg;
 

--- a/test/commands/ResourcesCommandTest.ts
+++ b/test/commands/ResourcesCommandTest.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { SinonSandbox, createSandbox } from "sinon";
+import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import Command from "../../src/abstracts/Command";
 import ResourcesCommand from "../../src/commands/ResourcesCommand";
@@ -8,28 +9,27 @@ describe("ResourcesCommand", () => {
 	describe("onInteract()", () => {
 		let sandbox: SinonSandbox;
 		let command: ResourcesCommand;
+		let replyStub: sinon.SinonStub<any[], any>;
+		let interaction: any;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			command = new ResourcesCommand();
+			replyStub = sandbox.stub().resolves();
+			interaction = {
+				reply: replyStub,
+				user: BaseMocks.getGuildMember()
+			};
 		});
 
 		it("sends a message to the channel", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract(undefined, {
-				reply: replyStub
-			});
+			await command.onInteract(interaction, undefined);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("sends the link to resources page if no argument is given", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract(undefined, {
-				reply: replyStub
-			});
+			await command.onInteract(interaction, undefined);
 
 			const { content: url } = replyStub.firstCall.lastArg;
 
@@ -38,11 +38,7 @@ describe("ResourcesCommand", () => {
 		});
 
 		it("sends link to the category page if an argument is given", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("javascript", {
-				reply: replyStub
-			});
+			await command.onInteract(interaction, "javascript");
 
 			const { content: url } = replyStub.firstCall.lastArg;
 

--- a/test/commands/RuleCommandTest.ts
+++ b/test/commands/RuleCommandTest.ts
@@ -1,5 +1,6 @@
 import { createSandbox, SinonSandbox } from "sinon";
 import { expect } from "chai";
+import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import RuleCommand from "../../src/commands/RuleCommand";
 import { EMBED_COLOURS } from "../../src/config.json";
@@ -8,28 +9,27 @@ describe("RuleCommand", () => {
 	describe("run()", () => {
 		let sandbox: SinonSandbox;
 		let command: RuleCommand;
+		let replyStub: sinon.SinonStub<any[], any>;
+		let interaction: any;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			command = new RuleCommand();
+			replyStub = sandbox.stub().resolves();
+			interaction = {
+				reply: replyStub,
+				user: BaseMocks.getGuildMember()
+			};
 		});
 
 		it("sends a message to the channel", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("0", {
-				reply: replyStub
-			});
+			await command.onInteract("0", interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("states rule 0 if you ask for rule 0", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("0", {
-				reply: replyStub
-			});
+			await command.onInteract("0", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -42,11 +42,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 1 if you ask for rule 1", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("1", {
-				reply: replyStub
-			});
+			await command.onInteract("1", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -59,11 +55,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 2 if you ask for rule 2", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("2", {
-				reply: replyStub
-			});
+			await command.onInteract("2", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -76,11 +68,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 3 if you ask for rule 3", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("3", {
-				reply: replyStub
-			});
+			await command.onInteract("3", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -93,11 +81,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 4 if you ask for rule 4", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("4", {
-				reply: replyStub
-			});
+			await command.onInteract("4", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -110,11 +94,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 5 if you ask for rule 5", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("5", {
-				reply: replyStub
-			});
+			await command.onInteract("5", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -127,11 +107,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 6 if you ask for rule 6", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("6", {
-				reply: replyStub
-			});
+			await command.onInteract("6", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -144,11 +120,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 7 if you ask for rule 7", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("7", {
-				reply: replyStub
-			});
+			await command.onInteract("7", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -161,11 +133,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 8 if you ask for rule 8", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("8", {
-				reply: replyStub
-			});
+			await command.onInteract("8", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -178,11 +146,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 9 if you ask for rule 9", async () => {
-			const replyStub = sandbox.stub().resolves();
-
-			await command.onInteract("9", {
-				reply: replyStub
-			});
+			await command.onInteract("9", interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 

--- a/test/commands/RuleCommandTest.ts
+++ b/test/commands/RuleCommandTest.ts
@@ -4,6 +4,7 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
 import RuleCommand from "../../src/commands/RuleCommand";
 import { EMBED_COLOURS } from "../../src/config.json";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("RuleCommand", () => {
 	describe("run()", () => {
@@ -34,11 +35,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Asking For Help");
-			expect(embed.description).to.equal("Help us to help you, instead of just saying \"my code doesn't work\" or \"can someone help me.\"");
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
+			expect(embed.data.title).to.equal("Rule: Asking For Help");
+			expect(embed.data.description).to.equal("Help us to help you, instead of just saying \"my code doesn't work\" or \"can someone help me.\"");
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
 		});
 
 		it("states rule 1 if you ask for rule 1", async () => {
@@ -47,11 +48,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Be Patient");
-			expect(embed.description).to.equal("Responses to your questions are not guaranteed. The people here offer their expertise on their own time and for free.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Be Patient");
+			expect(embed.data.description).to.equal("Responses to your questions are not guaranteed. The people here offer their expertise on their own time and for free.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 2 if you ask for rule 2", async () => {
@@ -60,11 +61,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Unsolicited Contact/Bumps");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.description).to.equal("Do not send unsolicited DMs, bump questions, or ping for questions outside of an established conversation.");
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Unsolicited Contact/Bumps");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.description).to.equal("Do not send unsolicited DMs, bump questions, or ping for questions outside of an established conversation.");
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 3 if you ask for rule 3", async () => {
@@ -73,11 +74,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Be Nice");
-			expect(embed.description).to.equal("Be respectful; no personal attacks, sexism, homophobia, transphobia, racism, hate speech or other disruptive behaviour.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Be Nice");
+			expect(embed.data.description).to.equal("Be respectful; no personal attacks, sexism, homophobia, transphobia, racism, hate speech or other disruptive behaviour.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 4 if you ask for rule 4", async () => {
@@ -86,11 +87,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: No Advertising");
-			expect(embed.description).to.equal("Don't advertise. If you're not sure whether it would be considered advertising or not, ask a moderator.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: No Advertising");
+			expect(embed.data.description).to.equal("Don't advertise. If you're not sure whether it would be considered advertising or not, ask a moderator.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 5 if you ask for rule 5", async () => {
@@ -99,11 +100,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Use The Right Channel");
-			expect(embed.description).to.equal("Stick to the correct channels. If you're unsure which channel to put your question in, you can ask in [#general](https://codesupport.dev/discord) which channel is best for your question.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Use The Right Channel");
+			expect(embed.data.description).to.equal("Stick to the correct channels. If you're unsure which channel to put your question in, you can ask in [#general](https://codesupport.dev/discord) which channel is best for your question.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 6 if you ask for rule 6", async () => {
@@ -112,11 +113,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Illegal/Immoral Tasks");
-			expect(embed.description).to.equal("Don't ask for help with illegal or immoral tasks. Doing so not only risks your continued participation in this community but is in violation of Discord's TOS and can get your account banned.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Illegal/Immoral Tasks");
+			expect(embed.data.description).to.equal("Don't ask for help with illegal or immoral tasks. Doing so not only risks your continued participation in this community but is in violation of Discord's TOS and can get your account banned.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 7 if you ask for rule 7", async () => {
@@ -125,11 +126,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: No Spoon-feeding");
-			expect(embed.description).to.equal("No spoon-feeding, it's not useful and won't help anyone learn.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: No Spoon-feeding");
+			expect(embed.data.description).to.equal("No spoon-feeding, it's not useful and won't help anyone learn.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 8 if you ask for rule 8", async () => {
@@ -138,11 +139,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Use Codeblocks");
-			expect(embed.description).to.equal("When posting code, please use code blocks (see the command `/codeblock` for help).");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Use Codeblocks");
+			expect(embed.data.description).to.equal("When posting code, please use code blocks (see the command `/codeblock` for help).");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		it("states rule 9 if you ask for rule 9", async () => {
@@ -151,11 +152,11 @@ describe("RuleCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Rule: Keep it Clean");
-			expect(embed.description).to.equal("Keep it appropriate, some people use this at school or at work.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
-			expect(embed.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
-			expect(embed.fields[0].value).to.equal("<#240884566519185408>");
+			expect(embed.data.title).to.equal("Rule: Keep it Clean");
+			expect(embed.data.description).to.equal("Keep it appropriate, some people use this at school or at work.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
+			expect(embed.data.fields[0].name).to.equal("To familiarise yourself with all of the server's rules please see");
+			expect(embed.data.fields[0].value).to.equal("<#240884566519185408>");
 		});
 
 		afterEach(() => {

--- a/test/commands/SearchCommandTest.ts
+++ b/test/commands/SearchCommandTest.ts
@@ -5,6 +5,7 @@ import { BaseMocks } from "@lambocreeper/mock-discord.js";
 import SearchCommand from "../../src/commands/SearchCommand";
 import InstantAnswerService from "../../src/services/InstantAnswerService";
 import { EMBED_COLOURS } from "../../src/config.json";
+import NumberUtils from "../../src/utils/NumberUtils";
 
 describe("SearchCommand", () => {
 	describe("onInteract()", () => {
@@ -41,9 +42,9 @@ describe("SearchCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Error");
-			expect(embed.description).to.equal("No results found.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.ERROR.toLowerCase());
+			expect(embed.data.title).to.equal("Error");
+			expect(embed.data.description).to.equal("No results found.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.ERROR.toLowerCase()));
 		});
 
 		it("states the result from the instant answer service", async () => {
@@ -58,10 +59,10 @@ describe("SearchCommand", () => {
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Example Heading");
-			expect(embed.description).to.equal("Example Description\n\n[View on example.com](https://example.com)");
-			expect(embed.footer.text).to.equal("Result powered by the DuckDuckGo API.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.SUCCESS.toLowerCase());
+			expect(embed.data.title).to.equal("Example Heading");
+			expect(embed.data.description).to.equal("Example Description\n\n[View on example.com](https://example.com)");
+			expect(embed.data.footer.text).to.equal("Result powered by the DuckDuckGo API.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.SUCCESS.toLowerCase()));
 		});
 
 		it("correctly renders URLs from websites with subdomains", async () => {
@@ -75,7 +76,7 @@ describe("SearchCommand", () => {
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
-			expect(embed.description).to.equal("The capybara is an adorable rodent.\n\n[View on en.wikipedia.org](https://en.wikipedia.org/wiki/Capybara)");
+			expect(embed.data.description).to.equal("The capybara is an adorable rodent.\n\n[View on en.wikipedia.org](https://en.wikipedia.org/wiki/Capybara)");
 		});
 
 		afterEach(() => {

--- a/test/commands/WebsiteCommandTest.ts
+++ b/test/commands/WebsiteCommandTest.ts
@@ -23,20 +23,20 @@ describe("WebsiteCommand", () => {
 		});
 
 		it("sends a message to the channel", async () => {
-			await command.onInteract(interaction, undefined);
+			await command.onInteract(undefined, interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("sends default link to website if no argument is given", async () => {
-			await command.onInteract(interaction, undefined);
+			await command.onInteract(undefined, interaction);
 
 			expect(replyStub.firstCall.firstArg).to.equal("https://codesupport.dev/");
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("sends the link to website + addon if argument is given", async () => {
-			await command.onInteract(interaction, "test");
+			await command.onInteract("test", interaction);
 
 			expect(replyStub.firstCall.firstArg).to.equal("https://codesupport.dev/test");
 			expect(replyStub.calledOnce).to.be.true;

--- a/test/commands/WebsiteCommandTest.ts
+++ b/test/commands/WebsiteCommandTest.ts
@@ -23,20 +23,20 @@ describe("WebsiteCommand", () => {
 		});
 
 		it("sends a message to the channel", async () => {
-			await command.onInteract(null, interaction);
+			await command.onInteract(interaction, undefined);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("sends default link to website if no argument is given", async () => {
-			await command.onInteract(null, interaction);
+			await command.onInteract(interaction, undefined);
 
 			expect(replyStub.firstCall.firstArg).to.equal("https://codesupport.dev/");
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("sends the link to website + addon if argument is given", async () => {
-			await command.onInteract("test", interaction);
+			await command.onInteract(interaction, "test");
 
 			expect(replyStub.firstCall.firstArg).to.equal("https://codesupport.dev/test");
 			expect(replyStub.calledOnce).to.be.true;

--- a/test/event/handlers/AutomaticMemberRoleHandlerTest.ts
+++ b/test/event/handlers/AutomaticMemberRoleHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants, GuildMember } from "discord.js";
+import { Events, GuildMember } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks } from "@lambocreeper/mock-discord.js";
 
@@ -8,10 +8,10 @@ import EventHandler from "../../../src/abstracts/EventHandler";
 
 describe("AutomaticMemberRoleHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for GUILD_MEMBER_ADD", () => {
+		it("creates a handler for guildMemberAdd", () => {
 			const handler = new AutomaticMemberRoleHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.GUILD_MEMBER_ADD);
+			expect(handler.getEvent()).to.equal(Events.GuildMemberAdd);
 		});
 	});
 

--- a/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
+++ b/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Events, Message, MessageAttachment } from "discord.js";
+import { Collection, Events, Message, AttachmentBuilder } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -29,7 +29,7 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 				author: BaseMocks.getUser()
 			});
 			message.client.user = BaseMocks.getUser();
-			message.attachments = new Collection<string, MessageAttachment>();
+			message.attachments = new Collection<string, AttachmentBuilder>();
 		});
 
 		it("does nothing when there are no attachments.", async () => {
@@ -41,7 +41,7 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("does nothing when there is a valid attachment.", async () => {
-			message.attachments.set("720390958847361064", new MessageAttachment("720390958847361064", "test.png"));
+			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.png" }));
 			const addMockSend = sandbox.stub(message.channel, "send");
 
 			await handler.handle(message);
@@ -49,7 +49,7 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("does nothing when a not allowed extension is uploaded in an exempt channel.", async () => {
-			message.attachments.set("720390958847361065", new MessageAttachment("720390958847361065", "test.exe"));
+			message.attachments.set("720390958847361065", new AttachmentBuilder("720390958847361065", { name: "test.exe" }));
 			message.channelId = MOD_CHANNEL_ID;
 			const addMockSend = sandbox.stub(message.channel, "send");
 
@@ -58,7 +58,7 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("isn't case sensitive", async () => {
-			message.attachments.set("720390958847361064", new MessageAttachment("720390958847361064", "test.PNG"));
+			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.PNG" }));
 			const addMockSend = sandbox.stub(message.channel, "send");
 
 			await handler.handle(message);
@@ -66,7 +66,7 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("sends a message and deletes the user's upload when there is an invalid attachment.", async () => {
-			message.attachments.set("720390958847361064", new MessageAttachment("720390958847361064", "test.cpp"));
+			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.cpp" }));
 			const addMockSend = sandbox.stub(message.channel, "send");
 			const addMockDelete = sandbox.stub(message, "delete");
 
@@ -81,8 +81,8 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("deletes the message when any attachment on the message is invalid.", async () => {
-			message.attachments.set("720390958847361064", new MessageAttachment("720390958847361064", "test.png"));
-			message.attachments.set("72039095884736104", new MessageAttachment("72039095884736105", "test.cpp"));
+			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.png" }));
+			message.attachments.set("72039095884736104", new AttachmentBuilder("72039095884736105", { name: "test.cpp" }));
 			const addMockSend = sandbox.stub(message.channel, "send");
 			const addMockDelete = sandbox.stub(message, "delete");
 

--- a/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
+++ b/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
@@ -6,6 +6,7 @@ import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 import { EMBED_COLOURS, MOD_CHANNEL_ID } from "../../../src/config.json";
 import EventHandler from "../../../src/abstracts/EventHandler";
 import CodeblocksOverFileUploadsHandler from "../../../src/event/handlers/CodeblocksOverFileUploadsHandler";
+import NumberUtils from "../../../src/utils/NumberUtils";
 
 describe("CodeblocksOverFileUploadsHandler", () => {
 	describe("constructor()", () => {
@@ -75,9 +76,9 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 
 			expect(addMockSend.calledOnce).to.be.true;
 			expect(addMockDelete.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Uploading Files");
-			expect(embed.description).to.equal("<@010101010101010101>, you tried to upload a \`.cpp\` file, which is not allowed. Please use codeblocks over attachments when sending code.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
+			expect(embed.data.title).to.equal("Uploading Files");
+			expect(embed.data.description).to.equal("<@010101010101010101>, you tried to upload a \`.cpp\` file, which is not allowed. Please use codeblocks over attachments when sending code.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
 		});
 
 		it("deletes the message when any attachment on the message is invalid.", async () => {
@@ -92,9 +93,9 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 
 			expect(addMockSend.calledOnce).to.be.true;
 			expect(addMockDelete.calledOnce).to.be.true;
-			expect(embed.title).to.equal("Uploading Files");
-			expect(embed.description).to.equal("<@010101010101010101>, you tried to upload a \`.cpp\` file, which is not allowed. Please use codeblocks over attachments when sending code.");
-			expect(embed.hexColor).to.equal(EMBED_COLOURS.DEFAULT.toLowerCase());
+			expect(embed.data.title).to.equal("Uploading Files");
+			expect(embed.data.description).to.equal("<@010101010101010101>, you tried to upload a \`.cpp\` file, which is not allowed. Please use codeblocks over attachments when sending code.");
+			expect(embed.data.color).to.equal(NumberUtils.hexadecimalToInteger(EMBED_COLOURS.DEFAULT.toLowerCase()));
 		});
 
 		afterEach(() => {

--- a/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
+++ b/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Events, Message, AttachmentBuilder } from "discord.js";
+import { Collection, Events, Message, Attachment, APIAttachment } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -30,7 +30,7 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 				author: BaseMocks.getUser()
 			});
 			message.client.user = BaseMocks.getUser();
-			message.attachments = new Collection<string, AttachmentBuilder>();
+			message.attachments = new Collection<string, Attachment>();
 		});
 
 		it("does nothing when there are no attachments.", async () => {
@@ -42,7 +42,15 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("does nothing when there is a valid attachment.", async () => {
-			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.png" }));
+			const attachment: APIAttachment = {
+				id: "720390958847361064",
+				filename: "test.png",
+				size: 500,
+				url: "test.png",
+				proxy_url: "test.png"
+			};
+
+			message.attachments.set("720390958847361064", Reflect.construct(Attachment, [attachment]));
 			const addMockSend = sandbox.stub(message.channel, "send");
 
 			await handler.handle(message);
@@ -50,7 +58,15 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("does nothing when a not allowed extension is uploaded in an exempt channel.", async () => {
-			message.attachments.set("720390958847361065", new AttachmentBuilder("720390958847361065", { name: "test.exe" }));
+			const attachment: APIAttachment = {
+				id: "720390958847361065",
+				filename: "test.exe",
+				size: 500,
+				url: "test.exe",
+				proxy_url: "test.exe"
+			};
+
+			message.attachments.set("720390958847361065", Reflect.construct(Attachment, [attachment]));
 			message.channelId = MOD_CHANNEL_ID;
 			const addMockSend = sandbox.stub(message.channel, "send");
 
@@ -59,7 +75,15 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("isn't case sensitive", async () => {
-			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.PNG" }));
+			const attachment: APIAttachment = {
+				id: "720390958847361064",
+				filename: "test.PNG",
+				size: 500,
+				url: "test.PNG",
+				proxy_url: "test.PNG"
+			};
+
+			message.attachments.set("720390958847361064", Reflect.construct(Attachment, [attachment]));
 			const addMockSend = sandbox.stub(message.channel, "send");
 
 			await handler.handle(message);
@@ -67,7 +91,15 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("sends a message and deletes the user's upload when there is an invalid attachment.", async () => {
-			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.cpp" }));
+			const attachment: APIAttachment = {
+				id: "720390958847361064",
+				filename: "test.cpp",
+				size: 500,
+				url: "test.cpp",
+				proxy_url: "test.cpp"
+			};
+
+			message.attachments.set("720390958847361064", Reflect.construct(Attachment, [attachment]));
 			const addMockSend = sandbox.stub(message.channel, "send");
 			const addMockDelete = sandbox.stub(message, "delete");
 
@@ -82,8 +114,24 @@ describe("CodeblocksOverFileUploadsHandler", () => {
 		});
 
 		it("deletes the message when any attachment on the message is invalid.", async () => {
-			message.attachments.set("720390958847361064", new AttachmentBuilder("720390958847361064", { name: "test.png" }));
-			message.attachments.set("72039095884736104", new AttachmentBuilder("72039095884736105", { name: "test.cpp" }));
+			const attachment: APIAttachment = {
+				id: "720390958847361064",
+				filename: "test.png",
+				size: 500,
+				url: "test.png",
+				proxy_url: "test.png"
+			};
+
+			const attachment2: APIAttachment = {
+				id: "72039095884736105",
+				filename: "test.cpp",
+				size: 500,
+				url: "test.cpp",
+				proxy_url: "test.cpp"
+			};
+
+			message.attachments.set("720390958847361064", Reflect.construct(Attachment, [attachment]));
+			message.attachments.set("72039095884736104", Reflect.construct(Attachment, [attachment2]));
 			const addMockSend = sandbox.stub(message.channel, "send");
 			const addMockDelete = sandbox.stub(message, "delete");
 

--- a/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
+++ b/test/event/handlers/CodeblocksOverFileUploadsHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, Message, MessageAttachment } from "discord.js";
+import { Collection, Events, Message, MessageAttachment } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -9,10 +9,10 @@ import CodeblocksOverFileUploadsHandler from "../../../src/event/handlers/Codebl
 
 describe("CodeblocksOverFileUploadsHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_CREATE", () => {
+		it("creates a handler for messageCreate", () => {
 			const handler = new CodeblocksOverFileUploadsHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_CREATE);
+			expect(handler.getEvent()).to.equal(Events.MessageCreate);
 		});
 	});
 

--- a/test/event/handlers/DiscordMessageLinkHandlerTest.ts
+++ b/test/event/handlers/DiscordMessageLinkHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants, Message, TextChannel } from "discord.js";
+import { Events, Message, TextChannel } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -9,10 +9,10 @@ import DiscordMessageLinkHandler from "../../../src/event/handlers/DiscordMessag
 
 describe("DiscordMessageLinkHandler", () => {
 	describe("Constructor()", () => {
-		it("creates a handler for MESSAGE_CREATE", () => {
+		it("creates a handler for messageCreate", () => {
 			const handler = new DiscordMessageLinkHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_CREATE);
+			expect(handler.getEvent()).to.equal(Events.MessageCreate);
 		});
 	});
 

--- a/test/event/handlers/GhostPingDeleteHandlerTest.ts
+++ b/test/event/handlers/GhostPingDeleteHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, Guild, Message, EmbedBuilder, MessageMentions, MessageReference } from "discord.js";
+import { Collection, Events, Guild, Message, EmbedBuilder, MessageMentions, MessageReference } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -8,10 +8,10 @@ import GhostPingDeleteHandler from "../../../src/event/handlers/GhostPingDeleteH
 
 describe("GhostPingDeleteHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_DELETE", () => {
+		it("creates a handler for messageDelete", () => {
 			const handler = new GhostPingDeleteHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_DELETE);
+			expect(handler.getEvent()).to.equal(Events.MessageDelete);
 		});
 	});
 

--- a/test/event/handlers/GhostPingDeleteHandlerTest.ts
+++ b/test/event/handlers/GhostPingDeleteHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, Guild, Message, MessageEmbed, MessageMentions, MessageReference } from "discord.js";
+import { Collection, Constants, Guild, Message, EmbedBuilder, MessageMentions, MessageReference } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -119,16 +119,16 @@ describe("GhostPingDeleteHandler", () => {
 			expect(fetchMessageStub.called).to.be.true;
 			const sentEmbed = messageMock.getCall(0).args[0].embeds[0];
 
-			expect(sentEmbed).to.be.an.instanceOf(MessageEmbed);
-			if (sentEmbed instanceof MessageEmbed) {
-				const replyToField = sentEmbed.fields.find(field => field.name === "Reply to");
+			expect(sentEmbed).to.be.an.instanceOf(EmbedBuilder);
+			if (sentEmbed instanceof EmbedBuilder) {
+				const replyToField = sentEmbed.data.fields?.find(field => field.name === "Reply to");
 
 				expect(replyToField).to.not.be.null;
 
-				const messageLinkField = sentEmbed.fields.find(field => field.name === "Message replied to");
+				const messageLinkField = sentEmbed.data.fields?.find(field => field.name === "Message replied to");
 
 				expect(messageLinkField).to.not.be.null;
-				expect(messageLinkField.value).to.equal("https://discord.com/channels/328194044587147279/328194044587147278/328194044587147280");
+				expect(messageLinkField?.value ?? "").to.equal("https://discord.com/channels/328194044587147279/328194044587147278/328194044587147280");
 			}
 		});
 

--- a/test/event/handlers/GhostPingDeleteHandlerTest.ts
+++ b/test/event/handlers/GhostPingDeleteHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Events, Guild, Message, EmbedBuilder, MessageMentions, MessageReference } from "discord.js";
+import { Collection, Events, Guild, Message, EmbedBuilder, MessageMentions, TextChannel } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -28,7 +28,7 @@ describe("GhostPingDeleteHandler", () => {
 			const message = CustomMocks.getMessage();
 			const messageMock = sandbox.stub(message.channel, "send");
 
-			message.mentions = new MessageMentions(message, [CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			message.content = "Hey <@328194044587147278>!";
 
 			await handler.handle(message);
@@ -40,7 +40,7 @@ describe("GhostPingDeleteHandler", () => {
 			const message = CustomMocks.getMessage();
 			const messageMock = sandbox.stub(message.channel, "send");
 
-			message.mentions = new MessageMentions(message, [], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [], [], false]);
 			message.content = "Hey everybody!";
 
 			await handler.handle(message);
@@ -57,7 +57,7 @@ describe("GhostPingDeleteHandler", () => {
 			author.bot = true;
 
 			message.author = author;
-			message.mentions = new MessageMentions(message, [BaseMocks.getUser()], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [BaseMocks.getUser()], [], false]);
 			message.content = "Hey <@328194044587147278>, stop spamming or we'll arrest you!";
 
 			await handler.handle(message);
@@ -70,7 +70,7 @@ describe("GhostPingDeleteHandler", () => {
 			const messageMock = sandbox.stub(message.channel, "send");
 
 			message.author = BaseMocks.getUser();
-			message.mentions = new MessageMentions(message, [CustomMocks.getUser()], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [CustomMocks.getUser()], [], false]);
 			message.content = `<@${message.author.id}>`;
 
 			await handler.handle(message);
@@ -85,7 +85,7 @@ describe("GhostPingDeleteHandler", () => {
 			const author = CustomMocks.getUser();
 
 			message.author = author;
-			message.mentions = new MessageMentions(message, [author, CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [author, CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			message.content = `<@${message.author.id}> <@328194044587147278>`;
 
 			await handler.handle(message);
@@ -95,7 +95,7 @@ describe("GhostPingDeleteHandler", () => {
 		it("provides additional info if message is a reply to another message", async () => {
 			const message = CustomMocks.getMessage({guild: CustomMocks.getGuild()});
 			const messageMock = sandbox.stub(message.channel, "send");
-			const channelMock = CustomMocks.getTextChannel();
+			const channelMock = CustomMocks.getTextChannel() as TextChannel;
 			const repliedToMessage = CustomMocks.getMessage({ id: "328194044587147280", guild: CustomMocks.getGuild()}, {
 				channel: CustomMocks.getTextChannel({ id: "328194044587147278"})
 			});
@@ -104,7 +104,7 @@ describe("GhostPingDeleteHandler", () => {
 			const author = CustomMocks.getUser();
 
 			message.author = author;
-			message.mentions = new MessageMentions(message, [CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			message.guild.id = "328194044587147279";
 			message.content = "this is a reply";
 			message.reference = {
@@ -114,6 +114,7 @@ describe("GhostPingDeleteHandler", () => {
 			};
 
 			await handler.handle(message);
+
 			expect(messageMock.called).to.be.true;
 			expect(resolveChannelStub.called).to.be.true;
 			expect(fetchMessageStub.called).to.be.true;
@@ -141,7 +142,7 @@ describe("GhostPingDeleteHandler", () => {
 			botUser.bot = true;
 
 			message.author = BaseMocks.getUser();
-			message.mentions = new MessageMentions(message, [message.author, botUser], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [message.author, botUser], [], false]);
 			message.content = `<@${message.author.id}> <@${botUser.id}>`;
 
 			await handler.handle(message);
@@ -160,7 +161,7 @@ describe("GhostPingDeleteHandler", () => {
 			botUser2.bot = true;
 
 			message.author = BaseMocks.getUser();
-			message.mentions = new MessageMentions(message, [botUser, botUser2], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [botUser, botUser2], [], false]);
 			message.content = `<@${botUser.id}> <@${botUser2.id}>`;
 
 			await handler.handle(message);
@@ -183,7 +184,7 @@ describe("GhostPingDeleteHandler", () => {
 			botUser.bot = true;
 
 			message.author = author;
-			message.mentions = new MessageMentions(message, [botUser], [], false);
+			message.mentions = Reflect.construct(MessageMentions, [message, [botUser], [], false]);
 			message.guild.id = "328194044587147279";
 			message.content = "this is a reply";
 			message.reference = {

--- a/test/event/handlers/GhostPingUpdateHandlerTest.ts
+++ b/test/event/handlers/GhostPingUpdateHandlerTest.ts
@@ -29,10 +29,10 @@ describe("GhostPingUpdateHandler", () => {
 			const newMessage = CustomMocks.getMessage();
 			const messageMock = sandbox.stub(oldMessage.channel, "send");
 
-			oldMessage.mentions = new MessageMentions(oldMessage, [CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			oldMessage.content = "Hey <@328194044587147278>!";
 
-			newMessage.mentions = new MessageMentions(newMessage, [], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [], [], false]);
 			newMessage.content = "Hey!";
 
 			await handler.handle(oldMessage, newMessage);
@@ -48,11 +48,11 @@ describe("GhostPingUpdateHandler", () => {
 			const author = CustomMocks.getUser({ id: "328194044587147279" });
 
 			oldMessage.author = author;
-			oldMessage.mentions = new MessageMentions(oldMessage, [author, CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [author, CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			oldMessage.content = `<@${oldMessage.author.id}> <@328194044587147278>`;
 
 			newMessage.author = author;
-			newMessage.mentions = new MessageMentions(newMessage, [author], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [author], [], false]);
 			newMessage.content = `<@${newMessage.author.id}>`;
 
 			await handler.handle(oldMessage, newMessage);
@@ -70,10 +70,10 @@ describe("GhostPingUpdateHandler", () => {
 			const mentionedUser3 = CustomMocks.getUser({ id: "328194044587147276" });
 			const mentionedUser4 = CustomMocks.getUser({ id: "328194044587147275" });
 
-			oldMessage.mentions = new MessageMentions(oldMessage, [mentionedUser1, mentionedUser2], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [mentionedUser1, mentionedUser2], [], false]);
 			oldMessage.content = "Waddup, <@328194044587147278> <@328194044587147277>!";
 
-			newMessage.mentions = new MessageMentions(newMessage, [mentionedUser3, mentionedUser4], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [mentionedUser3, mentionedUser4], [], false]);
 			newMessage.content = "Waddup, <@328194044587147276> <@328194044587147275>";
 
 			await handler.handle(oldMessage, newMessage);
@@ -86,10 +86,10 @@ describe("GhostPingUpdateHandler", () => {
 			const newMessage = CustomMocks.getMessage();
 			const messageMock = sandbox.stub(oldMessage.channel, "send");
 
-			oldMessage.mentions = new MessageMentions(oldMessage, [], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [], [], false]);
 			oldMessage.content = "Hey everybody!";
 
-			newMessage.mentions = new MessageMentions(newMessage, [], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [], [], false]);
 			newMessage.content = "Sup!";
 
 			await handler.handle(oldMessage, newMessage);
@@ -107,11 +107,11 @@ describe("GhostPingUpdateHandler", () => {
 			author.bot = true;
 
 			oldMessage.author = author;
-			oldMessage.mentions = new MessageMentions(oldMessage, [CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			oldMessage.content = "Welcome <@328194044587147278>!";
 
 			newMessage.author = author;
-			newMessage.mentions = new MessageMentions(newMessage, [], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [], [], false]);
 			newMessage.content = "Goodbye!";
 
 			await handler.handle(oldMessage, newMessage);
@@ -127,11 +127,11 @@ describe("GhostPingUpdateHandler", () => {
 			const author = CustomMocks.getUser({ id: "328194044587147279" });
 
 			oldMessage.author = author;
-			oldMessage.mentions = new MessageMentions(oldMessage, [CustomMocks.getUser({ id: oldMessage.author.id })], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [CustomMocks.getUser({ id: oldMessage.author.id })], [], false]);
 			oldMessage.content = `Sup <@${oldMessage.author.id}>`;
 
 			newMessage.author = author;
-			newMessage.mentions = new MessageMentions(newMessage, [], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [], [], false]);
 			newMessage.content = "Sup";
 
 			await handler.handle(oldMessage, newMessage);
@@ -147,11 +147,11 @@ describe("GhostPingUpdateHandler", () => {
 			const author = CustomMocks.getUser({ id: "328194044587147279" });
 
 			oldMessage.author = author;
-			oldMessage.mentions = new MessageMentions(oldMessage, [author, CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [author, CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			oldMessage.content = `<@${oldMessage.author.id}> <@328194044587147278>`;
 
 			newMessage.author = author;
-			newMessage.mentions = new MessageMentions(newMessage, [CustomMocks.getUser({ id: "328194044587147278" })], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [CustomMocks.getUser({ id: "328194044587147278" })], [], false]);
 			newMessage.content = "<@328194044587147278>";
 
 			await handler.handle(oldMessage, newMessage);
@@ -170,11 +170,11 @@ describe("GhostPingUpdateHandler", () => {
 			botUser.bot = true;
 
 			oldMessage.author = author;
-			oldMessage.mentions = new MessageMentions(oldMessage, [oldMessage.author, botUser], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [oldMessage.author, botUser], [], false]);
 			oldMessage.content = `Hey, <@${oldMessage.author.id}> <@${botUser.id}>`;
 
 			newMessage.author = author;
-			newMessage.mentions = new MessageMentions(newMessage, [], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [], [], false]);
 			newMessage.content = "Hey";
 
 			await handler.handle(oldMessage, newMessage);
@@ -195,11 +195,11 @@ describe("GhostPingUpdateHandler", () => {
 			botUser2.bot = true;
 
 			oldMessage.author = author;
-			oldMessage.mentions = new MessageMentions(oldMessage, [botUser1, botUser2], [], false);
+			oldMessage.mentions = Reflect.construct(MessageMentions, [oldMessage, [botUser1, botUser2], [], false]);
 			oldMessage.content = `Hey, <@${botUser1.id}> <@${botUser2.id}>`;
 
 			newMessage.author = author;
-			newMessage.mentions = new MessageMentions(newMessage, [], [], false);
+			newMessage.mentions = Reflect.construct(MessageMentions, [newMessage, [], [], false]);
 			newMessage.content = "Hey";
 
 			await handler.handle(oldMessage, newMessage);

--- a/test/event/handlers/GhostPingUpdateHandlerTest.ts
+++ b/test/event/handlers/GhostPingUpdateHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, Guild, Message, MessageMentions } from "discord.js";
+import { Collection, Events, Guild, Message, MessageMentions } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -8,10 +8,10 @@ import GhostPingUpdateHandler from "../../../src/event/handlers/GhostPingUpdateH
 
 describe("GhostPingUpdateHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_UPDATE", () => {
+		it("creates a handler for messageUpdate", () => {
 			const handler = new GhostPingUpdateHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_UPDATE);
+			expect(handler.getEvent()).to.equal(Events.MessageUpdate);
 		});
 	});
 

--- a/test/event/handlers/GhostPingUpdateHandlerTest.ts
+++ b/test/event/handlers/GhostPingUpdateHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, Guild, Message, MessageEmbed, MessageMentions } from "discord.js";
+import { Collection, Constants, Guild, Message, MessageMentions } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 

--- a/test/event/handlers/LogMemberLeaveHandlerTest.ts
+++ b/test/event/handlers/LogMemberLeaveHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, GuildMemberRoleManager, Role } from "discord.js";
+import { Collection, Events, GuildMemberRoleManager, Role } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 import { MEMBER_ROLE } from "../../../src/config.json";
@@ -10,10 +10,10 @@ import DateUtils from "../../../src/utils/DateUtils";
 
 describe("LogMemberLeaveHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for GUILD_MEMBER_REMOVE)", () => {
+		it("creates a handler for guildMemberRemove", () => {
 			const handler = new LogMemberLeaveHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.GUILD_MEMBER_REMOVE);
+			expect(handler.getEvent()).to.equal(Events.GuildMemberRemove);
 		});
 	});
 

--- a/test/event/handlers/LogMemberLeaveHandlerTest.ts
+++ b/test/event/handlers/LogMemberLeaveHandlerTest.ts
@@ -32,18 +32,35 @@ describe("LogMemberLeaveHandler", () => {
 
 			const guildMember = CustomMocks.getGuildMember({joined_at: new Date(1610478967732).toISOString()});
 
-			const roleCollection = new Collection([["12345", new Role(BaseMocks.getClient(), {
-				id: MEMBER_ROLE.toString(),
-				name: "member",
-				permissions: "1"
-			}, BaseMocks.getGuild())], [BaseMocks.getGuild().id, new Role(BaseMocks.getClient(), {
-				id: BaseMocks.getGuild().id,
-				name: "@everyone",
-				permissions: "1"
-			}, BaseMocks.getGuild())]]);
+			const roleCollection = new Collection([
+				[
+					"12345",
+					Reflect.construct(Role, [
+						BaseMocks.getClient(),
+						{
+							id: MEMBER_ROLE.toString(),
+							name: "member",
+							permissions: "1"
+						},
+						BaseMocks.getGuild()
+					])
+				],
+				[
+					BaseMocks.getGuild().id,
+					Reflect.construct(Role, [
+						BaseMocks.getClient(),
+						{
+							id: BaseMocks.getGuild().id,
+							name: "@everyone",
+							permissions: "1"
+						},
+						BaseMocks.getGuild()
+					])
+				]
+			]);
 
 			sandbox.stub(DateUtils, "getFormattedTimeSinceDate").returns("10 seconds");
-			sandbox.stub(GuildMemberRoleManager.prototype, "cache").get(() => roleCollection);
+			sandbox.stub(guildMember, "roles").get(() => ({ cache: roleCollection }));
 
 			await handler.handle(guildMember);
 

--- a/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
@@ -4,10 +4,9 @@ import { SinonSandbox, createSandbox } from "sinon";
 import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
 import EventHandler from "../../../src/abstracts/EventHandler";
-import MessageConfigOptions from "@lambocreeper/mock-discord.js/build/interfaces/MessageConfigOptions";
 import LogMessageBulkDeleteHandler from "../../../src/event/handlers/LogMessageBulkDeleteHandler";
 
-function messageFactory(amount: number, options: MessageConfigOptions | undefined = undefined) {
+function messageFactory(amount: number, options: { content: string; } | undefined = undefined) {
 	const collection = new Collection<Snowflake, Message>();
 
 	for (let i = 0; i < amount; i++) {
@@ -33,26 +32,41 @@ describe("LogMessageBulkDeleteHandler", () => {
 	describe("handle()", () => {
 		let sandbox: SinonSandbox;
 		let handler: EventHandler;
+		let collection: Collection<Snowflake, Message>;
 
 		beforeEach(() => {
 			sandbox = createSandbox();
 			handler = new LogMessageBulkDeleteHandler();
+			collection = new Collection<Snowflake, Message>();
 		});
 
 		it("sends a message in logs channel when a message is deleted", async () => {
-			const sendLogMock = sandbox.stub(Collection.prototype, "find");
+			const message = CustomMocks.getMessage({ content: "Test message" });
+			const sendLogMock = sandbox.stub(message.guild.channels.cache, "find");
 
-			await handler.handle(messageFactory(1));
+			collection.set("1", message);
+			await handler.handle(collection);
 
 			expect(sendLogMock.calledOnce).to.be.true;
 		});
 
 		it("sends messages in logs channel when multiple messages are deleted", async () => {
-			const sendLogMock = sandbox.stub(Collection.prototype, "find");
+			const message = CustomMocks.getMessage({ content: "Test message" });
+			const message2 = CustomMocks.getMessage({ content: "Test message" });
+			const message3 = CustomMocks.getMessage({ content: "Test message" });
+			const message4 = CustomMocks.getMessage({ content: "Test message" });
+			const message5 = CustomMocks.getMessage({ content: "Test message" });
+			const sendLogMock = sandbox.stub(message.guild.channels.cache, "find");
 
-			await handler.handle(messageFactory(5));
+			collection
+				.set("1", message)
+				.set("2", message2)
+				.set("3", message3)
+				.set("4", message4)
+				.set("5", message5);
+			await handler.handle(collection);
 
-			expect(sendLogMock.callCount).to.be.eq(5);
+			expect(sendLogMock.callCount).to.be.equal(5);
 		});
 
 		it("does not send a message in logs channel when message is deleted but content is empty - only image", async () => {

--- a/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
@@ -21,7 +21,7 @@ function messageFactory(amount: number, options: MessageConfigOptions | undefine
 	return collection;
 }
 
-describe("LogMessageDeleteHandler", () => {
+describe("LogMessageBulkDeleteHandler", () => {
 	describe("constructor()", () => {
 		it("creates a handler for messageBulkDelete", () => {
 			const handler = new LogMessageBulkDeleteHandler();

--- a/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageBulkDeleteHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Collection, Constants, Message, Snowflake } from "discord.js";
+import { Collection, Events, Message, Snowflake } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -23,10 +23,10 @@ function messageFactory(amount: number, options: MessageConfigOptions | undefine
 
 describe("LogMessageDeleteHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_Delete", () => {
+		it("creates a handler for messageBulkDelete", () => {
 			const handler = new LogMessageBulkDeleteHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_BULK_DELETE);
+			expect(handler.getEvent()).to.equal(Events.MessageBulkDelete);
 		});
 	});
 

--- a/test/event/handlers/LogMessageSingleDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageSingleDeleteHandlerTest.ts
@@ -6,7 +6,7 @@ import { CustomMocks } from "@lambocreeper/mock-discord.js";
 import EventHandler from "../../../src/abstracts/EventHandler";
 import LogMessageSingleDeleteHandler from "../../../src/event/handlers/LogMessageSingleDeleteHandler";
 
-describe("LogMessageDeleteHandler", () => {
+describe("LogMessageSingleDeleteHandler", () => {
 	describe("constructor()", () => {
 		it("creates a handler for messageDelete", () => {
 			const handler = new LogMessageSingleDeleteHandler();

--- a/test/event/handlers/LogMessageSingleDeleteHandlerTest.ts
+++ b/test/event/handlers/LogMessageSingleDeleteHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants } from "discord.js";
+import { Events } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -8,10 +8,10 @@ import LogMessageSingleDeleteHandler from "../../../src/event/handlers/LogMessag
 
 describe("LogMessageDeleteHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_Delete", () => {
+		it("creates a handler for messageDelete", () => {
 			const handler = new LogMessageSingleDeleteHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_DELETE);
+			expect(handler.getEvent()).to.equal(Events.MessageDelete);
 		});
 	});
 

--- a/test/event/handlers/LogMessageUpdateHandlerTest.ts
+++ b/test/event/handlers/LogMessageUpdateHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants, Message } from "discord.js";
+import { Events, Message } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -8,10 +8,10 @@ import LogMessageUpdateHandler from "../../../src/event/handlers/LogMessageUpdat
 
 describe("LogMessageUpdateHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_UPDATE", () => {
+		it("creates a handler for messageUpdate", () => {
 			const handler = new LogMessageUpdateHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_UPDATE);
+			expect(handler.getEvent()).to.equal(Events.MessageUpdate);
 		});
 	});
 

--- a/test/event/handlers/NewUserAuthenticationHandlerTest.ts
+++ b/test/event/handlers/NewUserAuthenticationHandlerTest.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { createSandbox, SinonSandbox } from "sinon";
-import { Constants, User } from "discord.js";
+import { Events, User } from "discord.js";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
 import NewUserAuthenticationHandler from "../../../src/event/handlers/NewUserAuthenticationHandler";
@@ -8,10 +8,10 @@ import EventHandler from "../../../src/abstracts/EventHandler";
 
 describe("NewUserAuthenticationHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for MESSAGE_REACTION_ADD", () => {
+		it("creates a handler for messageReactionAdd", () => {
 			const handler = new NewUserAuthenticationHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.MESSAGE_REACTION_ADD);
+			expect(handler.getEvent()).to.equal(Events.MessageReactionAdd);
 		});
 	});
 

--- a/test/event/handlers/NewUserAuthenticationHandlerTest.ts
+++ b/test/event/handlers/NewUserAuthenticationHandlerTest.ts
@@ -33,6 +33,7 @@ describe("NewUserAuthenticationHandler", () => {
 
 			const reaction = CustomMocks.getMessageReaction({
 				emoji: {
+					id: "3513548348434",
 					name: "🤖"
 				}
 			}, { message });
@@ -56,6 +57,7 @@ describe("NewUserAuthenticationHandler", () => {
 
 			const reaction = CustomMocks.getMessageReaction({
 				emoji: {
+					id: "1351534543545",
 					name: "😀"
 				}
 			}, { message });
@@ -79,6 +81,7 @@ describe("NewUserAuthenticationHandler", () => {
 
 			const reaction = CustomMocks.getMessageReaction({
 				emoji: {
+					id: "3513548348434",
 					name: "🤖"
 				}
 			}, { message });
@@ -102,6 +105,7 @@ describe("NewUserAuthenticationHandler", () => {
 
 			const reaction = CustomMocks.getMessageReaction({
 				emoji: {
+					id: "1351534543545",
 					name: "😀"
 				}
 			}, { message });

--- a/test/event/handlers/RaidDetectionHandlerTest.ts
+++ b/test/event/handlers/RaidDetectionHandlerTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Constants } from "discord.js";
+import { Events } from "discord.js";
 import { SinonSandbox, createSandbox } from "sinon";
 import { BaseMocks, CustomMocks } from "@lambocreeper/mock-discord.js";
 
@@ -9,10 +9,10 @@ import RaidDetectionHandler from "../../../src/event/handlers/RaidDetectionHandl
 
 describe("RaidDetectionHandler", () => {
 	describe("constructor()", () => {
-		it("creates a handler for GUILD_MEMBER_ADD", () => {
+		it("creates a handler for guildMemberAdd", () => {
 			const handler = new RaidDetectionHandler();
 
-			expect(handler.getEvent()).to.equal(Constants.Events.GUILD_MEMBER_ADD);
+			expect(handler.getEvent()).to.equal(Events.GuildMemberAdd);
 		});
 	});
 

--- a/test/utils/DiscordUtilsTest.ts
+++ b/test/utils/DiscordUtilsTest.ts
@@ -16,30 +16,37 @@ describe("DiscordUtils", () => {
 		});
 
 		it("returns GuildMember if value is a username + discriminator", async () => {
-			sandbox.stub(GuildMemberManager.prototype, "fetch").resolves(new Collection([["12345", member]]));
+			const guild = BaseMocks.getGuild();
 
-			expect(await DiscordUtils.getGuildMember("fakeUser#1234", BaseMocks.getGuild())).to.equal(member);
+			sandbox.stub(guild.members, "fetch").resolves(new Collection([["12345", member]]));
+
+			expect(await DiscordUtils.getGuildMember("fakeUser#1234", guild)).to.equal(member);
 		});
 
 		it("returns GuildMember if value is a username", async () => {
-			sandbox.stub(GuildMemberManager.prototype, "fetch").resolves(new Collection([["12345", member]]));
+			const guild = BaseMocks.getGuild();
 
-			expect(await DiscordUtils.getGuildMember("fakeUser", BaseMocks.getGuild())).to.equal(member);
+			sandbox.stub(guild.members, "fetch").resolves(new Collection([["12345", member]]));
+
+			expect(await DiscordUtils.getGuildMember("fakeUser", guild)).to.equal(member);
 		});
 
 		it("returns GuildMember if value is a userID", async () => {
-			// @ts-ignore (the types aren't recognising the overloaded fetch function)
-			sandbox.stub(GuildMemberManager.prototype, "fetch").resolves(member);
+			const guild = BaseMocks.getGuild();
 
-			expect(await DiscordUtils.getGuildMember("123456789", BaseMocks.getGuild())).to.equal(member);
+			// @ts-ignore (the types aren't recognising the overloaded fetch function)
+			sandbox.stub(guild.members, "fetch").resolves(member);
+
+			expect(await DiscordUtils.getGuildMember("123456789", guild)).to.equal(member);
 		});
 
 		it("returns GuildMember if value is a nickname", async () => {
+			const guild = BaseMocks.getGuild();
 			const nicknameMember = CustomMocks.getGuildMember({nick: "Lambo", user: user});
 
-			sandbox.stub(GuildMemberManager.prototype, "fetch").resolves(new Collection([["12345", nicknameMember]]));
+			sandbox.stub(guild.members, "fetch").resolves(new Collection([["12345", nicknameMember]]));
 
-			expect(await DiscordUtils.getGuildMember("Lambo", BaseMocks.getGuild())).to.equal(nicknameMember);
+			expect(await DiscordUtils.getGuildMember("Lambo", guild)).to.equal(nicknameMember);
 		});
 
 		afterEach(() => {

--- a/test/utils/NumberUtilsTest.ts
+++ b/test/utils/NumberUtilsTest.ts
@@ -9,4 +9,18 @@ describe("NumberUtils", () => {
 			expect(value).to.be.oneOf([1, 2, 3, 4, 5]);
 		});
 	});
+
+	describe("::hexadecimalToInteger()", () => {
+		it("Returns the decimal number from a hexadecimal value", () => {
+			const value = NumberUtils.hexadecimalToInteger("8AB54D");
+
+			expect(value).to.be.equal(9090381);
+		});
+
+		it("Returns the decimal number from a hexadecimal colour value", () => {
+			const value = NumberUtils.hexadecimalToInteger("#1555B7");
+
+			expect(value).to.be.equal(1398199);
+		});
+	});
 });


### PR DESCRIPTION
Resolves #247 

## IMPORTANT

Discord.js v14 needs node version 16.9.0 or above (previous one was 16.6.0)

### Overview
- Discord.js upgraded to 14.8.0
- DiscordX upgraded to 11.7.1


- Discord.js v14 includes the new permissions API v2, the `initApplicationPermissions` function from DiscordX was removed
- Most of the changes are updates to names of classes and parameters that need to be passed in as an object
- For slash commands the `required` default value was changed to `false`
- Made use of `Reflect.construct()` in the tests to be able to use all the private/protected constructors
