### PR TITLE
Member Name Changes

### DIFF
--- a/src/abstracts/LogMessageDeleteHandler.ts
+++ b/src/abstracts/LogMessageDeleteHandler.ts
@@ -11,7 +11,7 @@ abstract class LogMessageDeleteHandler extends EventHandler {
 				const embed = new EmbedBuilder();
 
 				embed.setTitle("Message Deleted");
-				embed.setDescription(`Author: ${message.author}\nChannel: ${message.channel}`);
+				embed.setDescription(`Author: ${message.author} (${message.author.username})\nChannel: ${message.channel}`);
 				embed.addFields([{ name: "Message", value: message.content }]);
 				embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 

--- a/src/commands/InspectCommand.ts
+++ b/src/commands/InspectCommand.ts
@@ -34,12 +34,12 @@ class InspectCommand {
 	private buildInspectEmbed(memberObj: GuildMember): EmbedBuilder {
 		const embed = new EmbedBuilder();
 
-		embed.setTitle(`Inspecting ${memberObj?.user.tag}`);
+		embed.setTitle(`Inspecting ${memberObj?.user.username}`);
 		embed.setColor(<ColorResolvable>(memberObj?.displayColor || getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT));
 		embed.setThumbnail(memberObj?.user.displayAvatarURL());
 		embed.addFields([
 			{ name: "User ID", value: memberObj?.user.id },
-			{ name: "Username", value: memberObj?.user.tag }
+			{ name: "Username", value: memberObj?.user.username }
 		]);
 
 		if (memberObj?.nickname !== null) embed.addFields([{ name: "Nickname", value: memberObj?.nickname }]);

--- a/src/event/handlers/LogMemberLeaveHandler.ts
+++ b/src/event/handlers/LogMemberLeaveHandler.ts
@@ -13,7 +13,7 @@ class LogMemberLeaveHandler extends EventHandler {
 		const embed = new EmbedBuilder();
 
 		embed.setTitle("Member Left");
-		embed.setDescription(`User: ${guildMember.user}`);
+		embed.setDescription(`User: ${guildMember.user} (${guildMember.user.username})`);
 		embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").DEFAULT);
 		embed.addFields([
 			{ name: "Join Date", value: new Date(guildMember.joinedTimestamp!).toLocaleString(), inline: true },

--- a/test/commands/InspectCommandTest.ts
+++ b/test/commands/InspectCommandTest.ts
@@ -75,11 +75,11 @@ describe("InspectCommand", () => {
 			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.data.title).to.equal(`Inspecting ${member.user.tag}`);
+			expect(embed.data.title).to.equal(`Inspecting ${member.user.username}`);
 			expect(embed.data.fields[0].name).to.equal("User ID");
 			expect(embed.data.fields[0].value).to.equal(member.user.id);
 			expect(embed.data.fields[1].name).to.equal("Username");
-			expect(embed.data.fields[1].value).to.equal(member.user.tag);
+			expect(embed.data.fields[1].value).to.equal(member.user.username);
 			expect(embed.data.fields[2].name).to.equal("Nickname");
 			expect(embed.data.fields[2].value).to.equal("my name");
 			expect(embed.data.fields[3].name).to.equal("Joined At");
@@ -104,9 +104,9 @@ describe("InspectCommand", () => {
 			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.data.title).to.equal(`Inspecting ${member.user.tag}`);
+			expect(embed.data.title).to.equal(`Inspecting ${member.user.username}`);
 			expect(embed.data.fields.find((field: EmbedField) => field.name === "User ID")?.value).to.equal(member.user.id);
-			expect(embed.data.fields.find((field: EmbedField) => field.name === "Username")?.value).to.equal(member.user.tag);
+			expect(embed.data.fields.find((field: EmbedField) => field.name === "Username")?.value).to.equal(member.user.username);
 			expect(embed.data.fields.find((field: EmbedField) => field.name === "Nickname")?.value ?? null).to.equal(member?.nickname);
 			expect(embed.data.fields.find((field: EmbedField) => field.name === "Joined At")?.value ?? null).to.equal(`${shortDateTime} ${relativeTime}`);
 			expect(embed.data.fields.find((field: EmbedField) => field.name === "Roles")?.value).to.equal(" <@&12345>");
@@ -127,11 +127,11 @@ describe("InspectCommand", () => {
 			const relativeTime = time(member?.joinedAt!, TimestampStyles.RelativeTime);
 
 			expect(replyStub.calledOnce).to.be.true;
-			expect(embed.data.title).to.equal(`Inspecting ${member.user.tag}`);
+			expect(embed.data.title).to.equal(`Inspecting ${member.user.username}`);
 			expect(embed.data.fields[0].name).to.equal("User ID");
 			expect(embed.data.fields[0].value).to.equal(member.user.id);
 			expect(embed.data.fields[1].name).to.equal("Username");
-			expect(embed.data.fields[1].value).to.equal(member.user.tag);
+			expect(embed.data.fields[1].value).to.equal(member.user.username);
 			expect(embed.data.fields[2].name).to.equal("Nickname");
 			expect(embed.data.fields[2].value).to.equal("my name");
 			expect(embed.data.fields[3].name).to.equal("Joined At");


### PR DESCRIPTION
This removes the use of Discord 'tags' (username + discriminator), since discriminators are now deprecated and just render `#0`. It also adds the inclusion of a user's username to logs in case of the instance that the user has left and is no longer cached.