### PR TITLE
Added Spam account ban counter, and Pinging via /rule

### DIFF
--- a/src/commands/RuleCommand.ts
+++ b/src/commands/RuleCommand.ts
@@ -66,7 +66,7 @@ class RuleCommand {
 
 			const cooldownValuePinger = getConfigValue<number>("RULE_PING_COOLDOWN_PINGER");
 
-			const lastTimePinger = this.lastPingPerPinger.get(userId);
+			const lastTimePinger = this.lastPingPerPinger.get(interaction.user.id);
 
 			if (lastTimePinger) {
 				const secondsPassed = (now - lastTimePinger) / 1000;

--- a/src/commands/RuleCommand.ts
+++ b/src/commands/RuleCommand.ts
@@ -1,4 +1,4 @@
-import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType} from "discord.js";
+import {ColorResolvable, CommandInteraction, EmbedBuilder, ApplicationCommandOptionType, User} from "discord.js";
 import {Discord, Slash, SlashChoice, SlashOption} from "discordx";
 import getConfigValue from "../utils/getConfigValue";
 import GenericObject from "../interfaces/GenericObject";
@@ -13,11 +13,18 @@ const rules = getConfigValue<Rule[]>("rules").map(it => ({name: it.name, value: 
 
 @Discord()
 class RuleCommand {
+	private lastPinged = new Map<string, number>();
+
 	@Slash({ name: "rule", description: "Get info about a rule" })
 	async onInteract(
 		@SlashChoice(...rules) @SlashOption({ name: "rule", description: "Name of a rule", type: ApplicationCommandOptionType.String, required: true }) ruleName: string,
-			interaction: CommandInteraction
-	): Promise<void> {
+		@SlashOption({ name: "user", description: "User to ping", type: ApplicationCommandOptionType.User, required: false}) mentionedUser: User | undefined,
+			interaction: CommandInteraction): Promise<void> {
+		if (interaction === undefined) {
+			console.error("Interaction is undefined in RuleCommand");
+			return;
+		}
+
 		const embed = new EmbedBuilder();
 
 		const rule = getConfigValue<Rule[]>("rules").find(rule => rule.triggers.includes(ruleName));
@@ -30,7 +37,34 @@ class RuleCommand {
 			embed.addFields([{ name: "To familiarise yourself with all of the server's rules please see", value: "<#240884566519185408>" }]);
 			embed.setColor(getConfigValue<GenericObject<ColorResolvable>>("EMBED_COLOURS").SUCCESS);
 		}
-		await interaction.reply({embeds: [embed]});
+		await interaction.reply({ embeds: [embed] });
+
+		if (mentionedUser) {
+			const userId = mentionedUser.id;
+			const now = Date.now();
+			const cooldownValue = getConfigValue<number>("RULE_PING_COOLDOWN");
+
+			const lastTime = this.lastPinged.get(userId);
+
+			if (lastTime) {
+				const secondsPassed = (now - lastTime) / 1000;
+
+				if (secondsPassed < cooldownValue) {
+					const remaining = (cooldownValue - secondsPassed).toFixed(0);
+
+					await interaction.followUp({
+						content: `Slow down! You can ping that user again in ${remaining}s.`,
+						ephemeral: true
+					});
+					return;
+				}
+			}
+
+			// If they passed the check, update the map with the new time
+			this.lastPinged.set(userId, now);
+
+			await interaction.followUp({ content: `<@${mentionedUser?.id}> Please read the rule mentioned above, and take a moment to familiarise yourself with the rules.` });
+		}
 	}
 }
 

--- a/src/config.json
+++ b/src/config.json
@@ -106,5 +106,6 @@
             "description": "Keep it appropriate, some people use this at school or at work."
         }
     ],
-    "RULE_PING_COOLDOWN": 20
+    "RULE_PING_COOLDOWN_PINGED": 30,
+    "RULE_PING_COOLDOWN_PINGER": 180
 }

--- a/src/config.json
+++ b/src/config.json
@@ -105,5 +105,6 @@
             "triggers": ["9", "sfw", "clean", "appropriate"],
             "description": "Keep it appropriate, some people use this at school or at work."
         }
-    ]
+    ],
+    "RULE_PING_COOLDOWN": 20
 }

--- a/src/event/handlers/AntiSpamHandler.ts
+++ b/src/event/handlers/AntiSpamHandler.ts
@@ -51,10 +51,10 @@ class AntiSpamHandler extends EventHandler {
 		}
 		const antiSpamMessages = await antiSpamChannel.messages.fetch({ limit: 100 });
 		// Check if any of those messages were sent by THIS bot
-		const hasSentMessageInAntiSpamChannel = antiSpamMessages.some((msg: Message) => (msg.author.id === message.client.user?.id) && (msg.embeds.length > 0));
+		const hasSentMessageInAntiSpamChannel = antiSpamMessages.some((msg: Message) => msg.author.id === message.client.user?.id && msg.embeds.length === 0);
 
-		if (hasSentMessageInAntiSpamChannel && antiSpamMessages.find((msg: Message) => (msg.author.id === message.client.user?.id) && (msg.embeds.length > 0))) {
-			const botMessage = antiSpamMessages.find((msg: Message) => (msg.author.id === message.client.user?.id) && (msg.embeds.length > 0));
+		if (hasSentMessageInAntiSpamChannel && antiSpamMessages.find((msg: Message) => msg.author.id === message.client.user?.id && msg.embeds.length === 0)) {
+			const botMessage = antiSpamMessages.find((msg: Message) => msg.author.id === message.client.user?.id && msg.embeds.length === 0);
 			const botMessageContent = botMessage!.content;
 			const counterValueStr = botMessageContent.split(" ")[0].replace(/\D/g, "");
 			const counterValueInt = parseInt(counterValueStr, 10);

--- a/src/event/handlers/AntiSpamHandler.ts
+++ b/src/event/handlers/AntiSpamHandler.ts
@@ -2,7 +2,6 @@ import {Events, Message, TextChannel} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import {logger} from "../../logger";
 import getConfigValue from "../../utils/getConfigValue";
-import LogMessageSingleDeleteHandler from "./LogMessageSingleDeleteHandler";
 
 class AntiSpamHandler extends EventHandler {
 	constructor() {

--- a/src/event/handlers/AntiSpamHandler.ts
+++ b/src/event/handlers/AntiSpamHandler.ts
@@ -21,6 +21,49 @@ class AntiSpamHandler extends EventHandler {
 
 		const member = message.member;
 
+		let antiSpamChannel = await message.guild.channels.fetch(antiSpamChannelId) as TextChannel;
+
+		if (!antiSpamChannel) { // Retry loop
+			let tries = 0;
+			let success = 0;
+
+			while (tries <= 3) {
+				antiSpamChannel = await message.guild.channels.fetch(antiSpamChannelId) as TextChannel;
+				if (antiSpamChannel) {
+					success = 1;
+					break;
+				}
+				tries += 1;
+			}
+			if (!success) {
+				logger.error("Failed to increment counter");
+				try {
+					await member.ban({deleteMessageSeconds: 60 * 60, reason: "Member posted in anti-spam channel"});
+
+					const logsChannel = await message.guild.channels.fetch(logsChannelId) as TextChannel;
+
+					await logsChannel.send(`User ${member.user.username} (\`${member.id}\`) was banned for posting in <#${antiSpamChannelId}>. Their recent messages have been deleted.`);
+				} catch (error) {
+					logger.error("AntiSpamHandler error", {error});
+				}
+				return;
+			}
+		}
+		const antiSpamMessages = await antiSpamChannel.messages.fetch({ limit: 100 });
+		// Check if any of those messages were sent by THIS bot
+		const hasSentMessageInAntiSpamChannel = antiSpamMessages.some(msg => msg.author.id === message.client.user?.id);
+
+		if (hasSentMessageInAntiSpamChannel && antiSpamMessages.find(msg => msg.author.id === message.client.user?.id)) {
+			const botMessage = antiSpamMessages.find(msg => msg.author.id === message.client.user?.id);
+			const botMessageContent = botMessage!.content;
+			const counterValueStr = botMessageContent.split(" ")[0].replace(/\D/g, "");
+			const counterValueInt = parseInt(counterValueStr, 10);
+
+			botMessage!.edit(`**${counterValueInt + 1}** spam accounts banned.`);
+		} else {
+			antiSpamChannel.send("**1** spam account has been banned.");
+		}
+
 		try {
 			await member.ban({deleteMessageSeconds: 60 * 60, reason: "Member posted in anti-spam channel"});
 

--- a/src/event/handlers/AntiSpamHandler.ts
+++ b/src/event/handlers/AntiSpamHandler.ts
@@ -2,6 +2,7 @@ import {Events, Message, TextChannel} from "discord.js";
 import EventHandler from "../../abstracts/EventHandler";
 import {logger} from "../../logger";
 import getConfigValue from "../../utils/getConfigValue";
+import LogMessageSingleDeleteHandler from "./LogMessageSingleDeleteHandler";
 
 class AntiSpamHandler extends EventHandler {
 	constructor() {
@@ -51,10 +52,10 @@ class AntiSpamHandler extends EventHandler {
 		}
 		const antiSpamMessages = await antiSpamChannel.messages.fetch({ limit: 100 });
 		// Check if any of those messages were sent by THIS bot
-		const hasSentMessageInAntiSpamChannel = antiSpamMessages.some(msg => msg.author.id === message.client.user?.id);
+		const hasSentMessageInAntiSpamChannel = antiSpamMessages.some((msg: Message) => (msg.author.id === message.client.user?.id) && (msg.embeds.length > 0));
 
-		if (hasSentMessageInAntiSpamChannel && antiSpamMessages.find(msg => msg.author.id === message.client.user?.id)) {
-			const botMessage = antiSpamMessages.find(msg => msg.author.id === message.client.user?.id);
+		if (hasSentMessageInAntiSpamChannel && antiSpamMessages.find((msg: Message) => (msg.author.id === message.client.user?.id) && (msg.embeds.length > 0))) {
+			const botMessage = antiSpamMessages.find((msg: Message) => (msg.author.id === message.client.user?.id) && (msg.embeds.length > 0));
 			const botMessageContent = botMessage!.content;
 			const counterValueStr = botMessageContent.split(" ")[0].replace(/\D/g, "");
 			const counterValueInt = parseInt(counterValueStr, 10);

--- a/test/appTest.ts
+++ b/test/appTest.ts
@@ -21,7 +21,9 @@ describe("App", () => {
 		sandbox = createSandbox();
 
 		// @ts-ignore
-		(axios as unknown as AxiosCacheInstance).defaults.cache = undefined;
+		const axiosCache = axios as unknown as AxiosCacheInstance;
+
+		axiosCache.defaults.cache = undefined;
 
 		loginStub = sandbox.stub(Client.prototype, "login");
 		getStub = sandbox.stub(axios, "get").resolves();

--- a/test/commands/RuleCommandTest.ts
+++ b/test/commands/RuleCommandTest.ts
@@ -24,13 +24,13 @@ describe("RuleCommand", () => {
 		});
 
 		it("sends a message to the channel", async () => {
-			await command.onInteract("0", interaction);
+			await command.onInteract("0", undefined, interaction);
 
 			expect(replyStub.calledOnce).to.be.true;
 		});
 
 		it("states rule 0 if you ask for rule 0", async () => {
-			await command.onInteract("0", interaction);
+			await command.onInteract("0", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -43,7 +43,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 1 if you ask for rule 1", async () => {
-			await command.onInteract("1", interaction);
+			await command.onInteract("1", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -56,7 +56,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 2 if you ask for rule 2", async () => {
-			await command.onInteract("2", interaction);
+			await command.onInteract("2", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -69,7 +69,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 3 if you ask for rule 3", async () => {
-			await command.onInteract("3", interaction);
+			await command.onInteract("3", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -82,7 +82,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 4 if you ask for rule 4", async () => {
-			await command.onInteract("4", interaction);
+			await command.onInteract("4", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -95,7 +95,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 5 if you ask for rule 5", async () => {
-			await command.onInteract("5", interaction);
+			await command.onInteract("5", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -108,7 +108,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 6 if you ask for rule 6", async () => {
-			await command.onInteract("6", interaction);
+			await command.onInteract("6", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -121,7 +121,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 7 if you ask for rule 7", async () => {
-			await command.onInteract("7", interaction);
+			await command.onInteract("7", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -134,7 +134,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 8 if you ask for rule 8", async () => {
-			await command.onInteract("8", interaction);
+			await command.onInteract("8", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 
@@ -147,7 +147,7 @@ describe("RuleCommand", () => {
 		});
 
 		it("states rule 9 if you ask for rule 9", async () => {
-			await command.onInteract("9", interaction);
+			await command.onInteract("9", undefined, interaction);
 
 			const embed = replyStub.getCall(0).firstArg.embeds[0];
 

--- a/test/event/handlers/AntiSpamHandlerTest.ts
+++ b/test/event/handlers/AntiSpamHandlerTest.ts
@@ -25,6 +25,62 @@ describe("AntiSpamHandler", () => {
 		const ANTISPAM_CHANNEL_ID = "antispam";
 		const LOG_CHANNEL_ID = "logs";
 
+		function createBotCounterMessage(count: number, overrides: Partial<any> = {}) {
+			return {
+				id: "bot-message-id",
+				content: `**${count}** spam accounts banned.`,
+				author: { id: "bot-id" },
+				embeds: [],
+				edit: sandbox.stub().resolves(),
+				...overrides
+			};
+		}
+		function setupAntiSpamChannelWithMessages(messages: any[]) {
+			const fakeAntiSpamChannel = {
+				id: ANTISPAM_CHANNEL_ID,
+				messages: {
+					fetch: sandbox.stub().resolves({
+						some: (fn: any) => messages.some(fn),
+						find: (fn: any) => messages.find(fn)
+					})
+				},
+				send: sandbox.stub().resolves()
+			};
+
+			messageMock.guild.channels.fetch = sandbox.stub().callsFake(async (id: string) => {
+				if (id === ANTISPAM_CHANNEL_ID) return fakeAntiSpamChannel;
+				if (id === LOG_CHANNEL_ID) return logsChannelMock;
+				return null;
+			});
+
+			return fakeAntiSpamChannel;
+		}
+		function setupFetchWithRetries(failuresBeforeSuccess: number | null, fakeAntiSpamChannel: any) {
+			let callCount = 0;
+
+			messageMock.guild.channels.fetch = sandbox.stub().callsFake(async (id: string) => {
+				if (id === LOG_CHANNEL_ID) {
+					return logsChannelMock;
+				}
+
+				if (id === ANTISPAM_CHANNEL_ID) {
+					if (failuresBeforeSuccess === null) {
+						// Always fail
+						return null;
+					}
+
+					if (callCount < failuresBeforeSuccess) {
+						callCount++;
+						return null;
+					}
+
+					return fakeAntiSpamChannel;
+				}
+
+				return null;
+			});
+		}
+
 		beforeEach(() => {
 			sandbox = createSandbox();
 			handler = new AntiSpamHandler();
@@ -86,10 +142,6 @@ describe("AntiSpamHandler", () => {
 			};
 		});
 
-		afterEach(() => {
-			sandbox.restore();
-		});
-
 		it("bans user with deleteMessageSeconds and logs when message is in anti-spam channel", async () => {
 			await handler.handle(messageMock);
 			expect(messageMock.member.ban.calledOnce).to.be.true;
@@ -124,6 +176,111 @@ describe("AntiSpamHandler", () => {
 			await handler.handle(messageMock);
 			expect(memberMock.ban.called).to.be.false;
 			expect(logsChannelMock.send.called).to.be.false;
+		});
+
+		[
+			[0, 1],
+			[4, 5],
+			[9, 10],
+			[10, 11],
+			[99, 100],
+			[100, 101],
+			[192831923, 192831924]
+		].forEach(([from, to]) => {
+			it(`counter already existing, modified correctly (${from} -> ${to})`, async () => {
+				const botMessage = createBotCounterMessage(from);
+
+				setupAntiSpamChannelWithMessages([botMessage]);
+
+				await handler.handle(messageMock);
+
+				expect(botMessage.edit.calledOnce).to.be.true;
+				expect(botMessage.edit.firstCall.args[0]).to.equal(`**${to}** spam accounts banned.`);
+			});
+		});
+
+		it("counter not already existing, created correctly (counter = 1)", async () => {
+			const fakeChannel = setupAntiSpamChannelWithMessages([]);
+
+			await handler.handle(messageMock);
+
+			expect(fakeChannel.send.calledOnce).to.be.true;
+			expect(fakeChannel.send.firstCall.args[0]).to.equal("**1** spam account has been banned.");
+		});
+
+		it("counter does not modify a previous message which contains embeds", async () => {
+			const botMessageWithEmbed = createBotCounterMessage(5, {
+				embeds: [{}]
+			});
+
+			setupAntiSpamChannelWithMessages([botMessageWithEmbed]);
+
+			await handler.handle(messageMock);
+
+			expect(botMessageWithEmbed.edit.called).to.be.false;
+		});
+
+		it("counter does not modify a previous message sent by another user", async () => {
+			const userMessage = createBotCounterMessage(5, {
+				author: { id: "some-user-id" }
+			});
+
+			setupAntiSpamChannelWithMessages([userMessage]);
+
+			await handler.handle(messageMock);
+
+			expect(userMessage.edit.called).to.be.false;
+		});
+
+		it("counter does not modify a previous message sent by another bot", async () => {
+			const otherBotMessage = createBotCounterMessage(5, {
+				author: { id: "another-bot-id" }
+			});
+
+			setupAntiSpamChannelWithMessages([otherBotMessage]);
+
+			await handler.handle(messageMock);
+
+			expect(otherBotMessage.edit.called).to.be.false;
+		});
+
+		[
+			{ failures: 1, shouldSucceed: true },
+			{ failures: 2, shouldSucceed: true },
+			{ failures: 3, shouldSucceed: true },
+			{ failures: 4, shouldSucceed: true },
+			{ failures: 5, shouldSucceed: false}
+		].forEach(({ failures, shouldSucceed }) => {
+			it(`retry logic: fetch fails ${failures} time(s) → ${shouldSucceed ? "succeeds" : "gives up"}`, async () => {
+				const botMessage = createBotCounterMessage(0);
+				const fakeChannel = setupAntiSpamChannelWithMessages([botMessage]);
+
+				let callCount = 0;
+
+				messageMock.guild.channels.fetch = sandbox.stub().callsFake(async (id: string) => {
+					if (id === LOG_CHANNEL_ID) {
+						return logsChannelMock;
+					}
+
+					if (id === ANTISPAM_CHANNEL_ID) {
+						callCount++;
+						return callCount <= failures ? null : fakeChannel;
+					}
+
+					return null;
+				});
+
+				await handler.handle(messageMock);
+
+				// Inline conditionals for assertions
+				expect(botMessage.edit.called).to.equal(shouldSucceed);
+				expect(messageMock.member.ban.calledOnce).to.be.true;
+				expect(logsChannelMock.send.called).to.equal(true);
+			});
+		});
+
+		afterEach(() => {
+			sandbox.restore();
 		});
 	});
 });


### PR DESCRIPTION
### Overview
Changes:
- There is now a counter for the number of spam accounts banned
- You can now pass an argument to the `/rule` command to also ping a certain person (cooldown of 30s per pinged person and of 3m per pinger)
